### PR TITLE
Add sbc_email module

### DIFF
--- a/sbc_email/README.rst
+++ b/sbc_email/README.rst
@@ -1,0 +1,34 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+    :alt: License: AGPL-3
+
+Sponsor to beneficiary email communication
+==========================================
+
+This module allows to send child letters to sponsors through email.
+
+Usage
+=====
+
+Used by the onramp_compassion module to send an email on reception of a new
+child letter.
+
+The letter is sent to the sponsor's email address, using a SendGrid email
+template corresponding to the sponsor's language. Templates for every language
+have to be registered in the TemplateList model after creating them on the
+`SendGrid web interface <https://sendgrid.com/templates>`_.
+
+The template should contain the following substitution variables which will be
+replaced with corresponding values:
+
+- ``{sponsor}`` Full name of the sponsor
+- ``{child}`` First name of the child
+- ``{letter_url}`` URL where the letter can be viewed/downloaded
+
+Credits
+=======
+
+Maintainer
+----------
+
+This module is maintained by
+`Compassion Switzerland <https://www.compassion.ch>`_.

--- a/sbc_email/__init__.py
+++ b/sbc_email/__init__.py
@@ -1,0 +1,11 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2016 Compassion CH (http://www.compassion.ch)
+#    Releasing children from poverty in Jesus' name
+#    @author: Roman Zoller
+#
+#    The licence is in the file __openerp__.py
+#
+##############################################################################
+from . import models

--- a/sbc_email/__openerp__.py
+++ b/sbc_email/__openerp__.py
@@ -1,0 +1,42 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#       ______ Releasing children from poverty      _
+#      / ____/___  ____ ___  ____  ____ ___________(_)___  ____
+#     / /   / __ \/ __ `__ \/ __ \/ __ `/ ___/ ___/ / __ \/ __ \
+#    / /___/ /_/ / / / / / / /_/ / /_/ (__  |__  ) / /_/ / / / /
+#    \____/\____/_/ /_/ /_/ .___/\__,_/____/____/_/\____/_/ /_/
+#                        /_/
+#                            in Jesus' name
+#
+#    Copyright (C) 2016 Compassion CH (http://www.compassion.ch)
+#    @author: Roman Zoller
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    'name': 'Sponsor to beneficiary email communication',
+    'version': '0.1',
+    'category': 'Other',
+    'author': 'Compassion CH',
+    'website': 'http://www.compassion.ch',
+    'depends': ['sbc_compassion', 'sendgrid'],
+    'data': [
+        'security/ir.model.access.csv',
+        'views/template_list_view.xml',
+    ],
+    'demo': [],
+    'installable': True,
+}

--- a/sbc_email/models/__init__.py
+++ b/sbc_email/models/__init__.py
@@ -1,0 +1,12 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2016 Compassion CH (http://www.compassion.ch)
+#    Releasing children from poverty in Jesus' name
+#    @author: Roman Zoller
+#
+#    The licence is in the file __openerp__.py
+#
+##############################################################################
+from . import sponsorship_correspondence
+from . import template_list

--- a/sbc_email/models/sponsorship_correspondence.py
+++ b/sbc_email/models/sponsorship_correspondence.py
@@ -16,29 +16,32 @@ class SponsorshipCorrespondence(models.Model):
     _inherit = 'sponsorship.correspondence'
 
     email_id = fields.Many2one('sendgrid.email')
+    email_sent_date = fields.Datetime(related='email_id.sent_date')
 
     ##########################################################################
     #                             PUBLIC METHODS                             #
     ##########################################################################
 
     @api.one
-    def send_email(self):
-        super(SponsorshipCorrespondence, self).send_email()
+    def process_letter(self):
+        super(SponsorshipCorrespondence, self).process_letter()
         template = self.env['sponsorship.templatelist'].search(
             [('lang', '=', self.correspondant_id.lang)]
         )
-
         sponsor = '{} {}'.format(self.correspondant_id.firstname,
                                  self.correspondant_id.lastname)
         child = self.child_id.firstname
-        self.email_id = self.env['sendgrid.email'].create({
-            'email_to': self.correspondant_id.email,
-            'layout_template_id': template.layout_template_id.id,
-            'text_template_id': template.text_template_id.id,
-            'substitution_ids': [
-                (0, _, {'key': 'sponsor', 'value': sponsor}),
-                (0, _, {'key': 'child', 'value': child}),
-                (0, _, {'key': 'letter_url', 'value': self.read_url}),
-            ],
-        })
-        self.email_id.send()
+        email_to = self.correspondant_id.email
+        if email_to:
+            # Create and send email
+            self.email_id = self.env['sendgrid.email'].create({
+                'email_to': email_to,
+                'layout_template_id': template.layout_template_id.id,
+                'text_template_id': template.text_template_id.id,
+                'substitution_ids': [
+                    (0, _, {'key': 'sponsor', 'value': sponsor}),
+                    (0, _, {'key': 'child', 'value': child}),
+                    (0, _, {'key': 'letter_url', 'value': self.read_url}),
+                ],
+            })
+            self.email_id.send()

--- a/sbc_email/models/sponsorship_correspondence.py
+++ b/sbc_email/models/sponsorship_correspondence.py
@@ -1,0 +1,44 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2016 Compassion CH (http://www.compassion.ch)
+#    Releasing children from poverty in Jesus' name
+#    @author: Roman Zoller
+#
+#    The licence is in the file __openerp__.py
+#
+##############################################################################
+
+from openerp import models, fields, api, _
+
+
+class SponsorshipCorrespondence(models.Model):
+    _inherit = 'sponsorship.correspondence'
+
+    email_id = fields.Many2one('sendgrid.email')
+
+    ##########################################################################
+    #                             PUBLIC METHODS                             #
+    ##########################################################################
+
+    @api.one
+    def send_email(self):
+        super(SponsorshipCorrespondence, self).send_email()
+        template = self.env['sponsorship.templatelist'].search(
+            [('lang', '=', self.correspondant_id.lang)]
+        )
+
+        sponsor = '{} {}'.format(self.correspondant_id.firstname,
+                                 self.correspondant_id.lastname)
+        child = self.child_id.firstname
+        self.email_id = self.env['sendgrid.email'].create({
+            'email_to': self.correspondant_id.email,
+            'layout_template_id': template.layout_template_id.id,
+            'text_template_id': template.text_template_id.id,
+            'substitution_ids': [
+                (0, _, {'key': 'sponsor', 'value': sponsor}),
+                (0, _, {'key': 'child', 'value': child}),
+                (0, _, {'key': 'letter_url', 'value': self.read_url}),
+            ],
+        })
+        self.email_id.send()

--- a/sbc_email/models/template_list.py
+++ b/sbc_email/models/template_list.py
@@ -1,0 +1,20 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2016 Compassion CH (http://www.compassion.ch)
+#    Releasing children from poverty in Jesus' name
+#    @author: Roman Zoller
+#
+#    The licence is in the file __openerp__.py
+#
+##############################################################################
+
+from openerp import models, fields
+
+
+class TemplateList(models.Model):
+    _name = 'sponsorship.templatelist'
+
+    lang = fields.Char()
+    layout_template_id = fields.Many2one('sendgrid.template')
+    text_template_id = fields.Many2one('email.template')

--- a/sbc_email/models/template_list.py
+++ b/sbc_email/models/template_list.py
@@ -15,6 +15,7 @@ from openerp import models, fields
 class TemplateList(models.Model):
     _name = 'sponsorship.templatelist'
 
+    name_id = fields.Many2one('sponsorship.templatename', 'Name')
     lang = fields.Char()
     layout_template_id = fields.Many2one('sendgrid.template')
     text_template_id = fields.Many2one('email.template')

--- a/sbc_email/models/template_name.py
+++ b/sbc_email/models/template_name.py
@@ -8,6 +8,11 @@
 #    The licence is in the file __openerp__.py
 #
 ##############################################################################
-from . import sponsorship_correspondence
-from . import template_list
-from . import template_name
+
+from openerp import models, fields
+
+
+class TemplateName(models.Model):
+    _name = 'sponsorship.templatename'
+
+    name = fields.Char()

--- a/sbc_email/security/ir.model.access.csv
+++ b/sbc_email/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+"id","name","model_id:id","group_id:id","perm_read","perm_write","perm_create","perm_unlink"
+"access_sponsorship_templatelist","Full access on sponsorship_templatelist","model_sponsorship_templatelist","child_compassion.group_sponsorship",1,1,1,1

--- a/sbc_email/views/template_list_view.xml
+++ b/sbc_email/views/template_list_view.xml
@@ -9,6 +9,7 @@
                 <form string="Templates">
                     <sheet>
                         <group colspan="2" col="2">
+                            <field name="name_id"/>
                             <field name="lang"/>
                             <field name="layout_template_id"/>
                             <field name="text_template_id"/>
@@ -24,6 +25,7 @@
             <field name="model">sponsorship.templatelist</field>
             <field name="arch" type="xml">
                 <tree string="Emails">
+                    <field name="name_id"/>
                     <field name="lang"/>
                     <field name="layout_template_id"/>
                     <field name="text_template_id"/>

--- a/sbc_email/views/template_list_view.xml
+++ b/sbc_email/views/template_list_view.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <!-- Form view -->
+        <record id="view_template_list_form" model="ir.ui.view">
+            <field name="name">sponsorship.templatelist.form</field>
+            <field name="model">sponsorship.templatelist</field>
+            <field name="arch" type="xml">
+                <form string="Templates">
+                    <sheet>
+                        <group colspan="2" col="2">
+                            <field name="lang"/>
+                            <field name="layout_template_id"/>
+                            <field name="text_template_id"/>
+                        </group>
+                    </sheet>
+                </form>
+            </field>
+        </record>
+
+        <!-- Tree view -->
+        <record id="view_template_list_tree" model="ir.ui.view">
+            <field name="name">sponsorship.templatelist.tree</field>
+            <field name="model">sponsorship.templatelist</field>
+            <field name="arch" type="xml">
+                <tree string="Emails">
+                    <field name="lang"/>
+                    <field name="layout_template_id"/>
+                    <field name="text_template_id"/>
+                </tree>
+            </field>
+        </record>
+
+        <!-- Action opening the tree view -->
+        <record id="open_view_template_list_tree" model="ir.actions.act_window">
+            <field name="name">Email Language Templates</field>
+            <field name="res_model">sponsorship.templatelist</field>
+            <field name="view_type">form</field>
+            <field name="view_mode">form,tree</field>
+            <field name="view_id" ref="view_template_list_tree"/>
+        </record>
+
+        <menuitem id="menu_sendgrid_template_list" parent="sbc_compassion.menu_sponsorship_correspondence"
+                  name="Email Language Templates"
+                  action="sbc_email.open_view_template_list_tree"/>
+
+    </data>
+</openerp>


### PR DESCRIPTION
This module allows to send child letters to sponsors through email.

Used by the onramp_compassion module to send an email on reception of a
new child letter.