### PR TITLE
CO-12 - Date Import BVR

### DIFF
--- a/sponsorship_switzerland/models/completion_rules.py
+++ b/sponsorship_switzerland/models/completion_rules.py
@@ -75,7 +75,9 @@ class StatementCompletionRule(models.Model):
             'account_id' : value,
             ...}
         """
-        ref = st_line['ref']
+        ref = ''
+        if 'ref' in st_line:
+            ref = st_line['ref']
         res = {}
         partner_obj = self.env['res.partner']
         partner = partner_obj.search(
@@ -104,7 +106,9 @@ class StatementCompletionRule(models.Model):
         If line ref match an invoice BVR Reference, update partner and account
         Then, call the generic st_line method to complete other values.
         """
-        ref = st_line['ref']
+        ref = ''
+        if 'ref' in st_line:
+            ref = st_line['ref']
         res = dict()
         partner = self._search_partner_by_bvr_ref(ref)
 


### PR DESCRIPTION
This commit prevents the BVR statement import from throwing the following exception :
```
 /home/erp/odoo/addons/account_bank_statement_import/account_bank_statement_import.py", line 49, in import_file
    stmts_vals = self._complete_stmts_vals(stmts_vals, journal, account_number)
  File "/home/erp/addons/compassion-accounting/account_statement_completion/models/bank_statement_import.py", line 31, in _complete_stmts_vals
    st_vals, line_vals)
  File "/home/erp/addons/compassion-accounting/account_statement_completion/models/completion_rules.py", line 78, in auto_complete
    result = method(stmts_vals, stmt_line)
  File "/home/erp/addons/compassion-switzerland/sponsorship_switzerland/models/completion_rules.py", line 107, in get_from_bvr_ref
    ref = st_line['ref']
KeyError: 'ref'
```