### PR TITLE
 CO-2267 : Controller Wordpress qui crée des partenaires

### DIFF
--- a/partner_compassion/models/__init__.py
+++ b/partner_compassion/models/__init__.py
@@ -17,3 +17,4 @@ from . import mail_message
 from . import product
 from . import mail_thread
 from . import advocate_engagement
+from . import match_partner

--- a/partner_compassion/models/match_partner.py
+++ b/partner_compassion/models/match_partner.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2019 Compassion CH (http://www.compassion.ch)
+#    Releasing children from poverty in Jesus' name
+#    @author: Christopher Meier <dev@c-meier.ch>
+#
+#    The licence is in the file __manifest__.py
+#
+##############################################################################
+
+from odoo import models
+
+
+class MatchPartner(models.AbstractModel):
+    """
+    Extend the matching so that all create partner must be checked by a human.
+    """
+    _inherit = 'res.partner.match'
+
+    def match_process_create_infos(self, infos):
+        create_infos = super(MatchPartner, self).match_process_create_infos(
+            infos
+        )
+
+        # Mark the partner to be validated
+        create_infos['state'] = 'pending'
+
+        return create_infos

--- a/website_compassion/forms/match_partner_form.py
+++ b/website_compassion/forms/match_partner_form.py
@@ -28,8 +28,7 @@ if not testing:
                 self.with_context(no_upsert=True)
             ).form_before_create_or_update(values, extra_values)
 
-        def after_partner_match(self, partner, new_partner, partner_vals,
-                                values, extra_values):
+        def match_after_match(self, partner, new_partner, partner_vals):
             """
             Activate partner if it was a linked contact.
             :param partner: res.partner record matched
@@ -51,9 +50,6 @@ if not testing:
                         'active': True,
                         'contact_id': False
                     })
-            if new_partner:
-                # Mark the partner to be validated
-                partner.state = 'pending'
-            super(PartnerMatchform, self).after_partner_match(
-                partner, new_partner, partner_vals, values, extra_values
+            return super(PartnerMatchform, self).match_after_match(
+                partner, new_partner, partner_vals
             )

--- a/website_event_compassion/forms/event_registration_step1.py
+++ b/website_event_compassion/forms/event_registration_step1.py
@@ -87,8 +87,7 @@ if not testing:
                 'user_id': event.user_id.id,
             })
 
-        def after_partner_match(self, partner, new_partner, partner_vals,
-                                values, extra_values):
+        def match_after_match(self, partner, new_partner, partner_vals):
             """
             For event registration, we want to be a bit more restrictive in
             the partner matching, because we allow several people to
@@ -97,24 +96,18 @@ if not testing:
             :param partner: res.partner record matched
             :param new_partner: True if a new partner was created
             :param partner_vals: partner vals extracted from form
-            :param values: event.registration values
-            :param extra_values: extra form values
             :return: None
             """
-            firstname = extra_values['partner_firstname']
-            lastname = extra_values['partner_lastname']
+            firstname = partner_vals['firstname']
+            lastname = partner_vals['lastname']
             if not new_partner and (firstname.lower() !=
                                     partner.firstname.lower() or
                                     lastname.lower() !=
                                     partner.lastname.lower()):
-                # Reconstruct partner vals (name info was deleted)
-                partner_vals = self._get_partner_vals(values, extra_values)
-                # We link the contact to the previously matched partner
-                partner_vals['state'] = 'pending'
-                values['partner_id'] = partner.create(partner_vals).id
+                return self.match_create(partner, partner_vals)
             else:
-                super(EventRegistrationForm, self).after_partner_match(
-                    partner, new_partner, partner_vals, values, extra_values)
+                return super(EventRegistrationForm, self).match_after_match(
+                    partner, new_partner, partner_vals)
 
         def _form_create(self, values):
             """Just create the main object (as superuser)."""


### PR DESCRIPTION
Configure le nouveau point d'entré pour les donations wordpress.

Doit être fusionné en même temps que CompassionCH/compassion-modules#931

CompassionCH/wp-plugins#2 utilise le nouveau point d'entrée. Donc à fusionné après cette PR (mais l'ancien comportement fonctionne toujours). 