### PR TITLE
CO-2488 Ending sponsorship communication

### DIFF
--- a/partner_communication_switzerland/models/contracts.py
+++ b/partner_communication_switzerland/models/contracts.py
@@ -529,6 +529,11 @@ class RecurringContract(models.Model):
         ).send_communication(cancellation, both=True)
         self.filtered(
             lambda s: s.end_reason != '1' and s.parent_id
+            and bool(s.activation_date)
+        ).send_communication(cancellation, correspondent=False)
+        self.filtered(
+            lambda s: s.end_reason != '1' and s.parent_id
+            and not bool(s.activation_date)
         ).send_communication(no_sub, correspondent=False)
 
     def _new_dossier(self):


### PR DESCRIPTION
add a variation about ending
 -> if an activated sponsorship end and is not cancelled
    it's a terminated communication that is send
