### PR TITLE
CO-2674 disable medical survey 

### DIFF
--- a/muskathlon/models/event_registration.py
+++ b/muskathlon/models/event_registration.py
@@ -40,7 +40,7 @@ class MuskathlonRegistration(models.Model):
         related='compassion_event_id.muskathlon_event_id')
     reg_id = fields.Char(string='Muskathlon registration ID', size=128)
 
-    is_visible = fields.Boolean(compute='_compute_is_visible')
+    is_in_two_months = fields.Boolean(compute='_compute_is_in_two_months')
 
     _sql_constraints = [
         ('reg_unique', 'unique(event_id,partner_id)',
@@ -76,12 +76,13 @@ class MuskathlonRegistration(models.Model):
             registration.amount_raised = amount_raised
         super(MuskathlonRegistration, (self - m_reg))._compute_amount_raised()
 
-    def _compute_is_visible(self):
-        """if the evenement is less than 2 months, the bolean will be false"""
-        today = datetime.date.today()
-        start_day = fields.Date.from_string(self.event_begin_date)
-        delta = start_day - today
-        self.is_visible = delta.days < 60
+    def _compute_is_in_two_months(self):
+        """this function define is the bollean hide or not the survey"""
+        for registration in self:
+            today = datetime.date.today()
+            start_day = fields.Date.from_string(registration.event_begin_date)
+            delta = start_day - today
+            registration.is_in_two_months = delta.days < 60
 
     @api.onchange('event_id')
     def onchange_event_id(self):

--- a/muskathlon/models/event_registration.py
+++ b/muskathlon/models/event_registration.py
@@ -10,6 +10,7 @@
 
 from odoo import models, fields, api, _
 from odoo.addons.queue_job.job import job, related_action
+import datetime
 
 
 class MuskathlonRegistration(models.Model):
@@ -38,6 +39,8 @@ class MuskathlonRegistration(models.Model):
     muskathlon_event_id = fields.Char(
         related='compassion_event_id.muskathlon_event_id')
     reg_id = fields.Char(string='Muskathlon registration ID', size=128)
+
+    is_visible = fields.Boolean(compute='_compute_is_visible')
 
     _sql_constraints = [
         ('reg_unique', 'unique(event_id,partner_id)',
@@ -72,6 +75,13 @@ class MuskathlonRegistration(models.Model):
             ))
             registration.amount_raised = amount_raised
         super(MuskathlonRegistration, (self - m_reg))._compute_amount_raised()
+
+    def _compute_is_visible(self):
+        """if the evenement is less than 2 months, the bolean will be false"""
+        today = datetime.date.today()
+        start_day = fields.Date.from_string(self.event_begin_date)
+        delta = start_day - today
+        self.is_visible = delta.days < 60
 
     @api.onchange('event_id')
     def onchange_event_id(self):

--- a/muskathlon/templates/muskathlon_views.xml
+++ b/muskathlon/templates/muskathlon_views.xml
@@ -67,7 +67,7 @@
 
         <template id="tripinfos_formatted" name="Muskathlon Trip Information">
             <t t-set="registration" t-value="partner.registration_ids[:1]"/>
-            <t t-set="count_tasks" t-value="len(registration.incomplete_task_ids) - int(not registration.is_visible)"/>
+            <t t-set="count_tasks" t-value="len(registration.incomplete_task_ids) - int(not registration.is_in_two_months)"/>
             <h3>Tasks <span class="badge compassion_background_blue" t-esc="count_tasks"/></h3>
             <div class="list-group">
                 <!-- Large picture -->
@@ -88,7 +88,7 @@
                     <a class="list-group-item list-group-item-success" t-attf-href="{{survey_url.replace('start', 'print')}}/{{survey_already_filled.token}}">See completed medical survey</a>
                 </t>
                 <t t-else="">
-                    <t t-if="registration.is_visible">
+                    <t t-if="registration.is_in_two_months">
                          <t t-if="survey_not_started">
                              <a class="list-group-item" t-attf-href="{{survey_url}}/{{survey_not_started.token}}">Complete medical survey</a>
                          </t>

--- a/muskathlon/templates/muskathlon_views.xml
+++ b/muskathlon/templates/muskathlon_views.xml
@@ -67,7 +67,7 @@
 
         <template id="tripinfos_formatted" name="Muskathlon Trip Information">
             <t t-set="registration" t-value="partner.registration_ids[:1]"/>
-            <t t-set="count_tasks" t-value="len(registration.incomplete_task_ids)"/>
+            <t t-set="count_tasks" t-value="len(registration.incomplete_task_ids) - int(not registration.is_visible)"/>
             <h3>Tasks <span class="badge compassion_background_blue" t-esc="count_tasks"/></h3>
             <div class="list-group">
                 <!-- Large picture -->
@@ -88,11 +88,13 @@
                     <a class="list-group-item list-group-item-success" t-attf-href="{{survey_url.replace('start', 'print')}}/{{survey_already_filled.token}}">See completed medical survey</a>
                 </t>
                 <t t-else="">
-                    <t t-if="survey_not_started">
-                        <a class="list-group-item" t-attf-href="{{survey_url}}/{{survey_not_started.token}}">Complete medical survey</a>
-                    </t>
-                    <t t-else="">
-                        <a class="list-group-item" t-attf-href="{{survey_url}}">Complete medical survey</a>
+                    <t t-if="registration.is_visible">
+                         <t t-if="survey_not_started">
+                             <a class="list-group-item" t-attf-href="{{survey_url}}/{{survey_not_started.token}}">Complete medical survey</a>
+                         </t>
+                         <t t-else="">
+                             <a class="list-group-item" t-attf-href="{{survey_url}}">Complete medical survey</a>
+                         </t>
                     </t>
                 </t>
                 <!-- Child protection charter -->


### PR DESCRIPTION
the medical survey is now hidden until the 60 last days (2 months) before the D-Day. Furthermore, the blue button is up to date with the number of task to do (if the survey is hidden, it just shows one task)