### PR TITLE
CO-2772 : shift the ref scan when partner ref is misaligned.

### DIFF
--- a/muskathlon/models/__init__.py
+++ b/muskathlon/models/__init__.py
@@ -9,6 +9,7 @@
 ##############################################################################
 
 from . import advocate_details
+from . import account_invoice_line
 from . import contracts
 from . import event_compassion
 from . import event_registration

--- a/muskathlon/models/account_invoice_line.py
+++ b/muskathlon/models/account_invoice_line.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2018 Compassion CH (http://www.compassion.ch)
+#    @author: Emanuel Cino <ecino@compassion.ch>
+#    @author: Sebastien Toth <popod@me.com>
+#
+#    The licence is in the file __manifest__.py
+#
+##############################################################################
+
+from odoo import models, api, fields
+
+
+class AccountInvoiceLine(models.Model):
+    _inherit = "account.invoice.line"
+
+    sent_to_4m = fields.Date('Sent to 4M', copy=False)
+    price_cents = fields.Float(compute='_compute_amount_cents')
+
+    @api.multi
+    def _compute_amount_cents(self):
+        for line in self:
+            line.price_cents = line.price_subtotal*100

--- a/muskathlon/views/recurring_contracts_view.xml
+++ b/muskathlon/views/recurring_contracts_view.xml
@@ -1,5 +1,36 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
+    <record id="invoice_line_inherit_muskathlon" model="ir.ui.view">
+        <field name="name">Invoice line inherit muskathlon</field>
+        <field name="model">account.invoice</field>
+        <field name="inherit_id" ref="account.invoice_supplier_form"/>
+        <field name="arch" type="xml">
+            <field name="invoice_line_tax_ids" position="after">
+                <field name="sent_to_4m"/>
+            </field>
+        </field>
+    </record>
+    <record id="view_invoice_line_form_inherit_muskathlon" model="ir.ui.view">
+        <field name="name">Invoice line view inherit muskathlon</field>
+        <field name="model">account.invoice.line</field>
+        <field name="inherit_id" ref="account.view_invoice_line_form"/>
+        <field name="arch" type="xml">
+            <field name="account_id" position="before">
+                <field name="sent_to_4m"/>
+            </field>
+        </field>
+    </record>
+    <record id="view_invoice_line_tree_4m" model="ir.ui.view">
+        <field name="name">account.invoice.line.4m.tree</field>
+        <field name="model">account.invoice.line</field>
+        <field name="inherit_id" ref="sponsorship_compassion.view_invoice_line_partner_tree"/>
+        <field name="arch" type="xml">
+            <field name="price_subtotal" position="after">
+                <field name="sent_to_4m"/>
+            </field>
+        </field>
+    </record>
+
     <!-- Action for writing sent_to_4m on invoice lines and contracts -->
     <record id="send_4m_action" model="ir.actions.server">
         <field name="name">Send to 4M</field>

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,4 +16,4 @@ Shapely
 simplejson
 pandas
 pyminizip
-pdf2image
+pdf2image==1.7.1

--- a/sponsorship_switzerland/models/completion_rules.py
+++ b/sponsorship_switzerland/models/completion_rules.py
@@ -81,7 +81,8 @@ class StatementCompletionRule(models.Model):
             ref = st_line['ref']
         res = {}
 
-        partner_ref = ref[9:16]
+        ref_index = 9  # position of the partner ref inside the BVR number.
+        partner_ref = ref[ref_index:16]
         partner_obj = self.env['res.partner']
         partner = partner_obj.search([('ref', '=', str(int(partner_ref)))])
         if not partner:
@@ -97,6 +98,7 @@ class StatementCompletionRule(models.Model):
                         ref)
                     partner = partner_obj.search([
                         ('ref', '=', str(int(flexible_ref)))])
+                    ref_index = flexible_ref_match.start(1)
         if len(partner) > 1:
             # Take only those who have active sponsorships
             partner = partner.filtered(lambda p: p.sponsorship_ids.filtered(
@@ -108,7 +110,7 @@ class StatementCompletionRule(models.Model):
                 # no open invoice corresponding to the payment. We may need to
                 # generate one depending on the payment type.
                 line_vals, new_invoice = self._generate_invoice(
-                    stmts_vals, st_line, partner)
+                    stmts_vals, st_line, partner, ref_index)
                 res.update(line_vals)
                 # Get the accounting partner (company)
                 res['partner_id'] = partner.commercial_partner_id.id
@@ -236,17 +238,23 @@ class StatementCompletionRule(models.Model):
     #                             PRIVATE METHODS                            #
     ##########################################################################
 
-    def _generate_invoice(self, stmts_vals, st_line, partner):
-        """ Generates an invoice corresponding to the statement line read
-            in order to reconcile the corresponding move lines.
+    def _generate_invoice(self, stmts_vals, st_line, partner, ref_index):
+        """
+        Generates an invoice corresponding to the statement line read
+        in order to reconcile the corresponding move lines.
 
-        :returns dict, boolean: st_line values to update, true if invoice is
+        :param stmts_vals: bank statement values
+        :param st_line: current statement line values
+        :param partner: matched partner
+        :param ref_index: starting index at which the partner ref was found
+        :return: dict, boolean: st_line values to update, true if invoice is
                                 created.
         """
         # Read data in english
         res = dict()
+        ref = st_line['ref']
         product = self.with_context(lang='en_US')._find_product_id(
-            st_line['ref'])
+            partner.ref, ref)
         if not product:
             return res, False
         # Don't gengerate invoice if it's a Sponsor gift
@@ -254,14 +262,29 @@ class StatementCompletionRule(models.Model):
             res['name'] = product.name
             contract_obj = self.env['recurring.contract'].with_context(
                 lang='en_US')
-            contract_number = int(st_line['ref'][16:21])
-            contract = contract_obj.search(
-                ['|',
-                 ('partner_id', '=', partner.id),
-                 ('correspondent_id', '=', partner.id),
-                 ('commitment_number', '=', contract_number),
-                 ('state', '!=', 'draft'),
-                 ('type', 'like', 'S')])
+            # the contract number should be found after the ref on 5 digits.
+            contract_index = ref_index + 7
+            contract_number = int(
+                ref[contract_index:contract_index+5])
+            search_criterias = [
+                '|',
+                ('partner_id', '=', partner.id),
+                ('correspondent_id', '=', partner.id),
+                ('state', '!=', 'draft'),
+                ('type', 'like', 'S')
+            ]
+            contract = contract_obj.search(search_criterias + [
+                ('commitment_number', '=', contract_number)])
+            if not contract:
+                # Maybe the ref is misaligned. Most people have a number < 10
+                # so we try to find this digit in the ref and see if we get
+                # lucky.
+                contract_number_match = re.search(
+                    partner.ref + r'0{1,4}(\d)', ref)
+                if contract_number_match:
+                    contract_number = int(contract_number_match.group(1))
+                    contract = contract_obj.search(search_criterias + [
+                        ('commitment_number', '=', contract_number)])
             if len(contract) == 1:
                 # Retrieve the birthday of child
                 birthdate = ""
@@ -288,7 +311,7 @@ class StatementCompletionRule(models.Model):
             'payment_term_id': 1,  # Immediate payment
             'payment_mode_id': self.env['account.payment.mode'].search(
                 [('name', '=', 'BVR')]).id,
-            'reference': st_line['ref'],
+            'reference': ref,
             'origin': stmts_vals['name']
         }
 
@@ -358,11 +381,20 @@ class StatementCompletionRule(models.Model):
 
         return partner
 
-    def _find_product_id(self, ref):
+    def _find_product_id(self, partner_ref, ref):
         """ Finds what kind of payment it is,
             based on the reference of the statement line. """
         product_obj = self.env['product.product'].with_context(lang='en_US')
-        payment_type = int(ref[21])
+        # Search for payment type in a flexible manner given its neighbours
+        payment_type_match = re.search(
+            partner_ref + r'0{1,4}[1-9]{1,3}([1-9])0', ref)
+        if payment_type_match:
+            payment_type = int(payment_type_match.group(1))
+            payment_type_index = payment_type_match.start(1)
+        else:
+            # Take payment type from its fixed position where it's supposed.
+            payment_type_index = -6
+            payment_type = int(ref[payment_type_index])
         product = 0
         if payment_type in range(1, 6):
             # Sponsor Gift
@@ -372,7 +404,8 @@ class StatementCompletionRule(models.Model):
         elif payment_type in range(6, 8):
             # Fund donation
             products = product_obj.search(
-                [('fund_id', '=', int(ref[22:26]))])
+                [('fund_id', '=', int(
+                    ref[payment_type_index+1:payment_type_index+5]))])
             product = products[0] if products else 0
 
         return product

--- a/sponsorship_switzerland/tests/test_completion_rules_switzerland.py
+++ b/sponsorship_switzerland/tests/test_completion_rules_switzerland.py
@@ -24,12 +24,13 @@ class TestCompletionRulesSwitzerland(TransactionCase):
 
         self.assertEqual(completion_result, {})
 
-    def test_matching_using_partner_reference__for_gifts(self):
+    def test_matching_using_partner_reference_for_gifts(self):
         partner_ref = '1512077'
         contract_not_in_db = '11111'
         gift_type = '4'
         st_line = {
-            'ref': 'xxxxxxxxx' + partner_ref + contract_not_in_db + gift_type
+            'ref': 'x' * 9 + partner_ref + contract_not_in_db + gift_type +
+            '0' * 5
         }
         self._insert_partner(ref=partner_ref)
 
@@ -49,7 +50,7 @@ class TestCompletionRulesSwitzerland(TransactionCase):
         self.assertTrue('partner_id' in completion_result)
         self.assertEqual(completion_result['partner_id'], 8)
 
-    def test_lookup_by_sponsor_name__with_multiple_matching(self):
+    def test_lookup_by_sponsor_name_with_multiple_matching(self):
         """
         Two partners match flexible search by name (User Demo and User
         Portal Demo) and the exact match should take precedence
@@ -62,7 +63,7 @@ class TestCompletionRulesSwitzerland(TransactionCase):
         self.assertTrue('partner_id' in completion_result)
         self.assertEqual(completion_result['partner_id'], 6)
 
-    def test_lookup_by_sponsor_name__for_companies(self):
+    def test_lookup_by_sponsor_name_for_companies(self):
         """
         Looking up corporate partner 'Agrolait'
         Edge case of having a single word instead of first + last name
@@ -75,7 +76,7 @@ class TestCompletionRulesSwitzerland(TransactionCase):
         self.assertTrue('partner_id' in completion_result)
         self.assertEqual(completion_result['partner_id'], 8)
 
-    def test_lookup_by_sponsor_name__with_wire_transfers(self):
+    def test_lookup_by_sponsor_name_with_wire_transfers(self):
         """
         The logic to split the names is slightly different
         """
@@ -87,7 +88,7 @@ class TestCompletionRulesSwitzerland(TransactionCase):
         self.assertTrue('partner_id' in completion_result)
         self.assertEqual(completion_result['partner_id'], 8)
 
-    def test_lsv_dd__for_postfinance(self):
+    def test_lsv_dd_for_postfinance(self):
         statement_line = {
             'name': u'anything\nKREDITKARTEN\nanything',
             'amount': 200
@@ -112,7 +113,7 @@ class TestCompletionRulesSwitzerland(TransactionCase):
         self.assertFalse('partner_id' in completion_result)
         self.assertTrue('account_id' in completion_result)
 
-    def test_lsv_dd__with_zero_amount(self):
+    def test_lsv_dd_with_zero_amount(self):
         rule = self._fetch_rule_by_function_name('get_from_lsv_dd')
         completion_result = rule.auto_complete([], {'amount': 0, 'name': ''})
 


### PR DESCRIPTION
I tried to improve further the match flexibility as well with fund types and product, because if partner ref is misaligned, the rest will as well be misaligned. @nbornand Could you please review this change?