### PR TITLE
CO-2957 Fix some S2B letters sent to translation despite not needed

### DIFF
--- a/sbc_switzerland/models/correspondence.py
+++ b/sbc_switzerland/models/correspondence.py
@@ -78,8 +78,11 @@ class Correspondence(models.Model):
                 if original_lang == french:
                     vals['original_language_id'] = creole.id
 
-            if original_lang.translatable and original_lang not in sponsorship\
-                    .child_id.project_id.field_office_id.spoken_language_ids:
+            # Languages the office/region understand
+            office = sponsorship.child_id.project_id.field_office_id
+            language_ids = office.spoken_language_ids + office.translated_language_ids
+
+            if original_lang.translatable and original_lang not in language_ids:
                 correspondence = super(Correspondence, self.with_context(
                     no_comm_kit=True)).create(vals)
                 correspondence.send_local_translate()


### PR DESCRIPTION
instead of just looking whether the language of the letter is in the field 'office.spoken_language' we also look in 'translated_language'.

translated_language is defined for 6 out of 28 field.office and takes value in {English, French, Kinyarwanda}

As a result, English is never sent to translation.