### PR TITLE
Upgrade report compassion

### DIFF
--- a/report_compassion/models/partner_communication.py
+++ b/report_compassion/models/partner_communication.py
@@ -74,7 +74,6 @@ class PartnerCommunication(models.Model):
 
     def _put_bvr_in_attachments(self, bvr, background):
         pdf_download = self._generate_pdf_data(bvr, background)
-        bvr.attachment_ids.unlink()
         return self._create_and_add_attachment(bvr, pdf_download)
 
     def _create_and_add_attachment(self, bvr, datas):
@@ -83,13 +82,14 @@ class PartnerCommunication(models.Model):
             "type": "binary",
             "datas": datas
         })
+        comm_attachment = self.env['partner.communication.attachment'].create({
+            "name": bvr.report_id.name,
+            "report_name": "report_compassion.a4_bvr",
+            "communication_id": bvr.id,
+            "attachment_id": attachment.id
+        })
         bvr.write({
-            'attachment_ids': [[0, 0, {
-                "name": bvr.report_id.name,
-                "report_name": "report_compassion.a4_bvr",
-                "communication_id": bvr.id,
-                "attachment_id": attachment.id
-            }]]
+            'attachment_ids': [(4, comm_attachment.id)]
         })
         return bvr
 

--- a/report_compassion/models/partner_communication.py
+++ b/report_compassion/models/partner_communication.py
@@ -7,6 +7,7 @@
 #    The licence is in the file __manifest__.py
 #
 ##############################################################################
+import base64
 from odoo import api, models, fields
 
 
@@ -40,11 +41,55 @@ class PartnerCommunication(models.Model):
         Update the count of succes story prints when sending a receipt.
         :return: True
         """
-        print_bvr = self.filtered(lambda j: j.send_mode == 'physical' and
-                                  j.product_id)
-        print_bvr.write({'report_id': self.env.ref(
-            'report_compassion.report_a4_bvr').id})
-        return super().send()
+        bvr_to_send = self.filtered(lambda j: j.send_mode in 'digital'
+                                    and j.product_id)
+        if bvr_to_send:
+            for bvr in bvr_to_send:
+                pdf_download = self._generate_pdf_data(bvr, background=True)
+                bvr.attachment_ids.unlink()
+                self._create_and_add_attachment(bvr, pdf_download)
+            return super(PartnerCommunication, bvr_to_send).send()
+
+        bvr_to_print = self.filtered(lambda j: j.send_mode in 'physical'
+                                     and j.product_id)
+        if bvr_to_print:
+            for bvr in bvr_to_print:
+                if bvr.report_id == self.env.ref('report_compassion.report_a4_bvr'):
+                    bvr.write({'report_id': self.env.ref(
+                        'report_compassion.report_a4_bvr').id})
+                else:
+                    pdf_download = self._generate_pdf_data(bvr, background=False)
+                    bvr.attachment_ids.unlink()
+                    self._create_and_add_attachment(bvr, pdf_download)
+            return super(PartnerCommunication, bvr_to_print).send()
+
+    def _create_and_add_attachment(self, bvr, datas):
+        attachment = self.env['ir.attachment'].create({
+            "name": bvr.report_id.name,
+            "type": "binary",
+            "datas": datas
+        })
+        bvr.write({
+            'attachment_ids': [[0, 0, {
+                "name": bvr.report_id.name,
+                "report_name": "report_compassion.a4_bvr",
+                "communication_id": bvr.id,
+                "attachment_id": attachment.id
+            }]]
+        })
+        return bvr
+
+    def _generate_pdf_data(self, bvr, background):
+        data = {
+            'doc_ids': bvr.id,
+            'product_id': bvr.product_id.id,
+            'background': background
+        }
+        report_ref = self.env.ref('report_compassion.report_a4_bvr')
+        pdf_data = report_ref.report_action(bvr, data=data)
+        return base64.encodebytes(
+            report_ref.render_qweb_pdf(
+                pdf_data['data']['doc_ids'], pdf_data['data'])[0])
 
     @api.model
     def _get_default_vals(self, vals, default_vals=None):

--- a/report_compassion/models/partner_communication.py
+++ b/report_compassion/models/partner_communication.py
@@ -51,17 +51,13 @@ class PartnerCommunication(models.Model):
         if bvr_both:
             origin = self.env.context.get('origin')
             for bvr in bvr_both:
-                if origin == 'email' or \
-                        (origin == 'print' and
+                if origin == 'both_email' or \
+                        (origin == 'both_print' and
                          bvr.report_id !=
                          self.env.ref('report_compassion.report_a4_bvr')):
                     # email part
-                    bvr = self._put_bvr_in_attachments(
-                        bvr, background=origin == 'email')
-                    if origin == 'print':
-                        # remove product from communication
-                        # as it is in the attachments
-                        bvr.product_id = False
+                    self._put_bvr_in_attachments(
+                        bvr, background=origin == 'both_email')
 
             return super(PartnerCommunication, bvr_both).send()
 
@@ -74,8 +70,6 @@ class PartnerCommunication(models.Model):
             for bvr in bvr_to_print:
                 if bvr.report_id != self.env.ref('report_compassion.report_a4_bvr'):
                     self._put_bvr_in_attachments(bvr, background=False)
-                    # remove product_id because of wrong report
-                    bvr.product_id = False
             return super(PartnerCommunication, bvr_to_print).send()
 
     def _put_bvr_in_attachments(self, bvr, background):


### PR DESCRIPTION
BVRs are now added as attachment when the communication is sent by email or has not the template "A4 BVR".

A bug was fixed; it should now be possible to choose the order in which we send a communication with send_mode == 'both'

There is still a bug with the body_html of the mail/letter not correctly created