### PR TITLE
Co 3099 Fix Postfinance redirect

### DIFF
--- a/payment_ogone_compassion/__manifest__.py
+++ b/payment_ogone_compassion/__manifest__.py
@@ -35,13 +35,14 @@
     'license': 'AGPL-3',
     'website': 'http://www.compassion.ch',
     'data': [
-        'data/payment_acquirer.xml',
+        'views/payment_ogone_templates.xml',
+        'data/payment_acquirer.xml'
     ],
     'depends': [
-        'website',                      # website
-        'payment_ogone',                # source/addons
-        'wordpress_configuration',      # compassion-modules
-        'queue_job'                     # oca_addons/queue
+        'website',  # website
+        'payment_ogone',  # source/addons
+        'wordpress_configuration',  # compassion-modules
+        'queue_job'  # oca_addons/queue
     ],
     'demo': [],
     'installable': True,

--- a/payment_ogone_compassion/data/payment_acquirer.xml
+++ b/payment_ogone_compassion/data/payment_acquirer.xml
@@ -5,9 +5,11 @@
             <field name="name">Postfinance</field>
             <field name="provider">ogone</field>
             <field name="company_id" ref="base.main_company"/>
-            <field name="image" type="base64" file="payment_ogone_compassion/static/src/img/postfinance.jpg"/>
-            <field name="view_template_id" ref="payment_ogone.ogone_form"/>
-            <field name="registration_view_template_id" ref="payment_ogone.ogone_s2s_form"/>
+            <field name="image" type="base64"
+                   file="payment_ogone_compassion/static/src/img/postfinance.jpg"/>
+            <field name="view_template_id" ref="payment_ogone_compassion.ogone_acquirer_button"/>
+            <field name="registration_view_template_id"
+                   ref="payment_ogone.ogone_s2s_form"/>
             <field name="environment">test</field>
             <field name="pre_msg"><![CDATA[
 <p>You will be redirected to Postfinance after clicking on the payment button.</p>]]></field>

--- a/payment_ogone_compassion/views/payment_ogone_templates.xml
+++ b/payment_ogone_compassion/views/payment_ogone_templates.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--Copied from https://github.com/odoo/odoo/blob/10.0/addons/payment_ogone/views/payment_ogone_templates.xml-->
+<!--The new template in Odoo 11 breaks our logic.-->
+<odoo>
+    <data>
+        <template id="ogone_acquirer_button">
+            <form t-if="acquirer" t-att-action="tx_url" method="post" target="_self">
+                <!-- seller -->
+                <input type='hidden' name='PSPID' t-att-value='PSPID'/>
+                <input type='hidden' name='ORDERID' t-att-value='ORDERID'/>
+                <input type='hidden' name='COM' t-att-value='COM'/>
+                <!-- cart -->
+                <input type='hidden' name='AMOUNT' t-att-value='AMOUNT or "0.0"'/>
+                <input type='hidden' name='CURRENCY' t-att-value='CURRENCY'/>
+                <!-- buyer -->
+                <input type='hidden' name='LANGUAGE' t-att-value='LANGUAGE'/>
+                <input type='hidden' name='CN' t-att-value='CN'/>
+                <input type='hidden' name='EMAIL' t-att-value='EMAIL'/>
+                <input type='hidden' name='OWNERZIP' t-att-value='OWNERZIP'/>
+                <input type='hidden' name='OWNERADDRESS' t-att-value='OWNERADDRESS'/>
+                <input type='hidden' name='OWNERCTY' t-att-value='OWNERCTY'/>
+                <input type='hidden' name='OWNERTOWN' t-att-value='OWNERTOWN'/>
+                <input type='hidden' name='OWNERTELNO' t-att-value='OWNERTELNO'/>
+                <t t-if="acquirer.save_token in ['ask', 'always']">
+                    <input type='hidden' name='ALIAS' t-att-value='ALIAS'/>
+                    <input type='hidden' name='ALIASUSAGE' t-att-value='ALIASUSAGE'/>
+                </t>
+                <!-- before payment verification -->
+                <input type='hidden' name='SHASIGN' t-att-value='SHASIGN'/>
+
+                <!-- after payment parameters -->
+                <t t-if='PARAMPLUS'>
+                    <input type='hidden' name="PARAMPLUS" t-att-value='PARAMPLUS'/>
+                </t>
+                <!-- redirection -->
+                <input type='hidden' name='ACCEPTURL' t-att-value='ACCEPTURL'/>
+                <input type='hidden' name='DECLINEURL' t-att-value='DECLINEURL'/>
+                <input type='hidden' name='EXCEPTIONURL' t-att-value='EXCEPTIONURL'/>
+                <input type='hidden' name='CANCELURL' t-att-value='CANCELURL'/>
+                <!-- submit -->
+                <button type="submit" width="100px"
+                        t-att-class="submit_class">
+                    <img t-if="not submit_txt"
+                         src="/payment_ogone/static/src/img/ogone_icon.png"/>
+                    <span t-if="submit_txt">
+                        <t t-esc="submit_txt"/>
+                        <span class="fa fa-long-arrow-right"/>
+                    </span>
+                </button>
+            </form>
+        </template>
+    </data>
+</odoo>


### PR DESCRIPTION
In Odoo 11, there are major changes in payment including a [new payment form](https://github.com/odoo/odoo/commit/2df9c22d80be82b4ed7ffcd79f858e46c34e6479#diff-6b3bf59852d51bd845e333022ff9f6ae).

This fix only reuses the v10 `ogone_acquirer_button` instead of the v11 `ogone_form` to render the payment / redirection button. The new Odoo 11 logic doesn't use an html form which also breaks the automatic redirection from [cms_form](https://github.com/CompassionCH/compassion-modules/blob/a9e14965fc281dee2611cecb421e5f7da06f9971/cms_form_compassion/static/src/js/modal_form.js#L17)

Closes #1033 