### PR TITLE
CO-3101 Fix send_introduction_letter bug

### DIFF
--- a/partner_communication_switzerland/models/contracts.py
+++ b/partner_communication_switzerland/models/contracts.py
@@ -60,6 +60,9 @@ class RecurringContract(models.Model):
     def _do_not_send_letter_to_transfer(self):
         if self.origin_id.type == 'transfer':
             self.send_introduction_letter = False
+        # If origin is switched back from a transer, field should be reset to default
+        else:
+            self.send_introduction_letter = True
 
     def _compute_payment_type_attachment(self):
         for contract in self:

--- a/sbc_switzerland/models/correspondence.py
+++ b/sbc_switzerland/models/correspondence.py
@@ -122,14 +122,11 @@ class Correspondence(models.Model):
         intro_letter = self.env.ref(
             'sbc_compassion.correspondence_type_new_sponsor')
         for letter in self:
-            # if letter.original_language_id in \
-            #         letter.supporter_languages_ids or \
-            if (letter.beneficiary_language_ids &
-                    letter.supporter_languages_ids) or \
+            if intro_letter in letter.communication_type_ids and not \
+                    letter.sponsorship_id.send_introduction_letter:
+                continue
+            if (letter.beneficiary_language_ids & letter.supporter_languages_ids) or \
                     letter.has_valid_language:
-                if intro_letter in letter.communication_type_ids and not \
-                        letter.sponsorship_id.send_introduction_letter:
-                    continue
                 if super(Correspondence, letter).process_letter():
                     letters_to_send += letter
 


### PR DESCRIPTION
- Previously if the letter had to be translated, it would not go through the `send_introduction_letter` boolean check as the if statement is inside the translation check. Then it would be sent from `update_translation` without `send_introduction_letter` being checked. To fix this I moved the nested if outside. Couldn't test properly but it's highly likely this was the cause.

- Also found a small problem while trying to reproduce the bug, in the interface if a transfer is set as origin the `send_introduction_letter` field appears and is set to `False`. If the origin is changed the field disappears from the view but is still `False`. Therefore I think we should revert to True when the origin is changed to something that is not a transfer.