### PR TITLE
CO-3235 Fix Welcome active sent multiple times

### DIFF
--- a/partner_communication_switzerland/models/contracts.py
+++ b/partner_communication_switzerland/models/contracts.py
@@ -354,11 +354,12 @@ class RecurringContract(models.Model):
             ('welcome_active_letter_sent', '=', False)
         ])
         if to_send:
-            to_send.send_communication(welcome, both=True).send()
             to_send.write({
                 'sds_state': 'active',
                 'welcome_active_letter_sent': True
             })
+            to_send.send_communication(welcome, both=True).send()
+
 
     @api.model
     def send_sponsorship_reminders(self):

--- a/partner_communication_switzerland/models/contracts.py
+++ b/partner_communication_switzerland/models/contracts.py
@@ -360,7 +360,6 @@ class RecurringContract(models.Model):
             })
             to_send.send_communication(welcome, both=True).send()
 
-
     @api.model
     def send_sponsorship_reminders(self):
         logger.info("Creating Sponsorship Reminders")


### PR DESCRIPTION
Hypothesis: some error / timeout occurs when sending the communication, and as such the sponsorships never get welcome_active_letter_sent set to True. If this is the case, by setting to true first, we ensure that it is not sent multiple times, but some communications may not be sent.