### PR TITLE
CO-3258: Filter reconcile propositions by reference

### DIFF
--- a/account_reconcile_compassion/models/account_reconcile_model.py
+++ b/account_reconcile_compassion/models/account_reconcile_model.py
@@ -194,3 +194,36 @@ class AccountReconcileModel(models.Model):
         # Oldest due dates come first.
         full_query += " ORDER BY aml_date_maturity, aml_id"
         return full_query, all_params
+
+    # Filter out the automatically matched propositions to those with the same ref
+    # This isn't optimal performance wise but seems to be the simplest option.
+    # In some special cases, matches can be lost, more info in the commit.
+    @api.multi
+    def _apply_rules(self, st_lines, excluded_ids=None, partner_map=None):
+        matching_amls = super()._apply_rules(st_lines, excluded_ids, partner_map)
+
+        # Fetch all matching_amls recordsets at once to avoid hitting the db too often
+        matching_amls_recordset = self.env["account.move.line"].browse(
+            [x for l in matching_amls.values() for x in l["aml_ids"]]
+        )
+
+        st_lines_ids_that_have_a_match = [
+            k for k, v in matching_amls.items() if v["aml_ids"]
+        ]
+
+        # Filter out statement lines that have a match without the same reference
+        for line in st_lines:
+            if line.id in st_lines_ids_that_have_a_match:
+                matching_lines = matching_amls_recordset.browse(
+                    matching_amls[line.id]["aml_ids"]
+                )
+
+                # Remove matching_lines that don't have a ref or don't have the same
+                for matching_line in matching_lines:
+                    if (
+                        not matching_line.statement_line_id.ref
+                        or line.ref != matching_line.statement_line_id.ref
+                    ):
+                        matching_amls[line.id]["aml_ids"].remove(matching_line.id)
+
+        return matching_amls


### PR DESCRIPTION
This fix was chosen for simplicity as it isn't optimal performance wise. Also as the results are first fetched by apply_rules and then filtered by reference, some propositions can be lost. For example if a customer has two 50.- payments, the first one can be matched with an invoice without the same ref and then be filtered out. The second payment could have the right reference but won't be selected because it was already for the first one.