### PR TITLE
FIX analytic_account_id in reconcile js

### DIFF
--- a/account_reconcile_compassion/static/src/js/account_move_reconciliation.js
+++ b/account_reconcile_compassion/static/src/js/account_move_reconciliation.js
@@ -507,7 +507,7 @@ odoo.define("account_reconcile_compassion.reconciliation", function (require) {
             result.user_id = prop.user_id ? prop.user_id.id : null;
             result.comment = prop.comment;
             result.avoid_mobile_donation_notification = prop.avoid_mobile_donation_notification ? prop.avoid_mobile_donation_notification : false;
-            result.analytic_account_id = prop.analytic_account_id.id
+            result.analytic_account_id = prop.analytic_account_id ? prop.analytic_account_id.id : null;
             return result;
         },
     });


### PR DESCRIPTION
Need to check if analytic_account_id is defined before getting the id, otherwise when it is null will give error undefined.