### PR TITLE
CO-3258 Update reconcile matches and propositions

### DIFF
--- a/account_reconcile_compassion/models/account_reconciliation_widget.py
+++ b/account_reconcile_compassion/models/account_reconciliation_widget.py
@@ -66,11 +66,12 @@ class AccountReconciliationWidget(models.AbstractModel):
     def _domain_move_lines_for_reconciliation(self, st_line, aml_accounts, partner_id,
                                               excluded_ids=None, search_str=False):
         """
-        Restrict propositions to move lines with same references as bank statement line
+        Restrict propositions to move lines that don't have the same account
         """
         domain = super()._domain_move_lines_for_reconciliation(
             st_line, aml_accounts, partner_id, excluded_ids, search_str
         )
-        if st_line.ref:
-            domain = expression.AND([domain, [("ref", "ilike", st_line.ref)]])
+        domain = expression.AND([domain, [
+            ("account_id", "!=", st_line.journal_id.default_credit_account_id.id)
+        ]])
         return domain


### PR DESCRIPTION
- Found a way to add SQL parameters to the original match query, which should give better results and be more efficient than filtering out afterwards.
- Added filtering of account.move.lines that have the same account than the statement line for both propositions and matches

I tried the idea of using the first result of the proposition and completely bypassing _apply_rules() but it's way too slow as the query is executed for each statement line.