### PR TITLE
CO-3275 fix Youtube/Vimeo video integration in crowdfunding project

### DIFF
--- a/crowdfunding_compassion/templates/presentation_page.xml
+++ b/crowdfunding_compassion/templates/presentation_page.xml
@@ -116,8 +116,8 @@
                                     <p>
                                         <t t-esc="project.description"/>
                                     </p>
-                                    <t t-if="project.presentation_video">
-                                        <iframe class="my-3" width="100%" height="400px" t-att-src="project.presentation_video" frameborder="0"/>
+                                    <t t-if="project.presentation_video_embed">
+                                        <iframe class="my-3" width="100%" height="400px" t-att-src="project.presentation_video_embed" frameborder="0"/>
                                     </t>
                                 </t>
 


### PR DESCRIPTION
Fix video integration in Crowdfunding projects by creating an embedded version of the URL that is copy-pasted from the address bar. Only works for Youtube and Vimeo URLs for now. The fix handles URLs that already represent an embedded video.