### PR TITLE
CO-3234 fix fund_id uniqueness in product_template

### DIFF
--- a/partner_compassion/models/product.py
+++ b/partner_compassion/models/product.py
@@ -7,13 +7,33 @@
 #    The licence is in the file __manifest__.py
 #
 ##############################################################################
-from odoo import models, fields
+from odoo import api, models, fields
+from odoo.exceptions import ValidationError
+
+
+def check_fund_id(record):
+    products = record.env[record._name].search([
+        ('fund_id', '!=', 0),
+        ('id', '!=', record.id)
+    ])
+    list_fund_id = [product.fund_id for product in products]
+    if record.fund_id in list_fund_id:
+        raise ValidationError("The Fund already exists in database.")
+    if record.fund_id < 0:
+        raise ValidationError("The Fund cannot have a negative value")
 
 
 class ProductTemplate(models.Model):
     _inherit = "product.template"
+    _sql_constraints = [
+        ('fund_id_unique', "unique(fund_id)", "The Fund already exists in database.")
+    ]
 
-    fund_id = fields.Integer(size=4)
+    fund_id = fields.Integer(size=4, readonly=False)
+
+    @api.constrains('fund_id')
+    def _check_fund_id(self):
+        check_fund_id(self)
 
 
 class Product(models.Model):


### PR DESCRIPTION
Note that if there are existing records for the model in the database, then any field values have to be unique, or _sql_constraints attribute of the model will fail and OpenERP will do nothing to enforce the constraint for new records. This if the case for fund_id = 0, which is already non-unique for product.tempate.

Implemented _sql_contraints attribute nonetheless but added api.constrains decorator on fund_id.
