### PR TITLE
CO-3299 Child packs are now fixed

### DIFF
--- a/report_compassion/report/childpack.xml
+++ b/report_compassion/report/childpack.xml
@@ -254,6 +254,7 @@
                     <p t-raw="o.get_date('birthdate', 'date_short')" class="summary_field birthday"/>
                     <p t-field="o.project_id.country_id.name" class="summary_field country"/>
                 </div>
+                <p style="page-break-after:always;"/>
             </div>
         </template>
 
@@ -325,6 +326,7 @@
                             <br/>
                             <span t-field="o.local_id" class="ref"/>
                         </div>
+                        <p style="page-break-after:always;"/>
                     </div>
                 </t>
             </div>

--- a/report_compassion/wizards/print_childpack.py
+++ b/report_compassion/wizards/print_childpack.py
@@ -11,8 +11,9 @@ import base64
 from datetime import date
 
 from odoo.tools import relativedelta
+from odoo.exceptions import Warning as odooWarning
 
-from odoo import api, models, fields
+from odoo import _, api, models, fields
 
 
 class PrintChildpack(models.TransientModel):
@@ -73,6 +74,8 @@ class PrintChildpack(models.TransientModel):
                     not c.completion_date or c.completion_date > in_two_years)
                 ).with_context(lang=self.lang)
         )
+        if not records:
+            raise odooWarning(_("None of the children from the childpack can be printed !"))
         data = {
             "lang": self.lang,
             "doc_ids": records.ids,


### PR DESCRIPTION
All the children from a childpack were printed on the same page of the PDF report generated by _Qweb_. This PR solves this issue. Also, selected children in a childpack were filtered and if they were all dropped, an empty PDF file was generated. Now, an error message is displayed directly in the case where no children should be printed. 