### PR TITLE
CO-3206 fix name inversion when creating linked parnter

### DIFF
--- a/partner_compassion/views/partner_compassion_view.xml
+++ b/partner_compassion/views/partner_compassion_view.xml
@@ -198,7 +198,7 @@
         <field name="inherit_id" ref="partner_contact_in_several_companies.view_partner_form_inherit"/>
         <field name="arch" type="xml">
             <field name="other_contact_ids" position="before">
-                <field name="contact_id" invisible="1"/>
+                <field name="contact_id" invisible="0"/>
             </field>
             <xpath expr="//field[@name='other_contact_ids']/.." position="attributes">
                 <attribute name="string">Linked Partners</attribute>


### PR DESCRIPTION
This bug is fixed by changing the key's value of partner_names_order in Settings>Technical>Parameters>System Parameters from first_last to last_first_comma.