### PR TITLE
CO-3307 Crowdfunding fixes

### DIFF
--- a/crowdfunding_compassion/controllers/projects_controller.py
+++ b/crowdfunding_compassion/controllers/projects_controller.py
@@ -44,8 +44,8 @@ class ProjectsController(Controller, FormControllerMixin):
 
         form = request.httprequest.form
         direction = form.get("wiz_submit")
-
-        if not direction and not "save" in kwargs:
+        save = kwargs.get("save")
+        if not direction and not save:
             values.update({"refresh": True})
 
         # This allows the translation to still work on the page

--- a/crowdfunding_compassion/forms/project_creation_form.py
+++ b/crowdfunding_compassion/forms/project_creation_form.py
@@ -64,7 +64,7 @@ class ProjectCreationWizard(models.AbstractModel):
         if direction == "prev":
             step_values = self._prepare_step_values_to_store(self.request.form, {})
             self.wiz_save_step(step_values)
-        return super().form_next_url(main_object) + "?save"
+        return super().form_next_url(main_object) + "?save=True"
 
 
 class ProjectCreationFormStep1(models.AbstractModel):
@@ -228,7 +228,7 @@ class ProjectCreationStep2(models.AbstractModel):
     def form_next_url(self, main_object=None):
         url = super().form_next_url(main_object)
         if main_object:
-            url += f"?project_id={main_object.id}"
+            url += f"&project_id={main_object.id}"
         return url
 
 

--- a/crowdfunding_compassion/templates/project_creation_page.xml
+++ b/crowdfunding_compassion/templates/project_creation_page.xml
@@ -199,6 +199,13 @@
                     </div>
                 </div>
             </t>
+
+            <!-- If the project is joined, disable the back button to step 1 -->
+            <t t-if="form.main_object">
+                <script>
+                    document.querySelector("button[value='prev']").style.visibility = 'hidden';
+                </script>
+            </t>
         </template>
 
         <record id="project_creation_page" model="website.page">

--- a/crowdfunding_compassion/templates/project_donation_page.xml
+++ b/crowdfunding_compassion/templates/project_donation_page.xml
@@ -18,7 +18,13 @@
                             <t t-if="project.product_id">
                                 <div class="col-sm-12 col-md-4 mb-3">
                                     <label class="h-100 w-100">
-                                        <input type="radio" name="donation-type" value="fund" class="card-input-element d-none" />
+                                        <!-- If there is no sponsorship, select fund by default -->
+                                        <t t-if="project.number_sponsorships_goal">
+                                            <input type="radio" name="donation-type" value="fund" class="card-input-element d-none" />
+                                        </t>
+                                        <t t-else="">
+                                            <input type="radio" name="donation-type" value="fund" class="card-input-element d-none" checked="checked" />
+                                        </t>
 
                                         <div class="card h-100 card-body d-flex justify-content-around align-items-center">
                                             <img class="donation-type__card-icon" t-attf-src="data:image/png;base64, #{ project.product_id.image_medium }" t-if="isinstance(project.product_id.image_medium, bytes)"/>
@@ -35,29 +41,31 @@
                             </t>
 
                             <!-- Sponsorship selectable card -->
-                            <div class="col-sm-12 col-md-4 mb-3">
-                                <label class="h-100 w-100">
-                                    <!-- If there is no product id, select sponsorship by default -->
-                                    <t t-if="project.product_id">
-                                        <input type="radio" name="donation-type" value="sponsorship" class="card-input-element d-none" />
-                                    </t>
-                                    <t t-else="">
-                                        <input type="radio" name="donation-type" value="sponsorship" class="card-input-element d-none" checked="checked" />
-                                    </t>
-
-                                    <div class="card h-100 card-body d-flex justify-content-around align-items-center">
-                                        <img class="donation-type__card-icon"
-                                             src="/crowdfunding_compassion/static/src/img/icn_children.png"/>
-                                        <h4 class="blue text-center uppercase">Sponsor a child</h4>
-                                        <h6 class="blue text-center uppercase">(You will be redirected to compassion switzerland website)</h6>
-
-                                        <!-- Show the select button also if there is a fund option-->
+                            <t t-if="project.number_sponsorships_goal">
+                                <div class="col-sm-12 col-md-4 mb-3">
+                                    <label class="h-100 w-100">
+                                        <!-- If there is no product id, select sponsorship by default -->
                                         <t t-if="project.product_id">
-                                            <span class="fake-btn my-3 uppercase">Select</span>
+                                            <input type="radio" name="donation-type" value="sponsorship" class="card-input-element d-none" />
                                         </t>
-                                    </div>
-                                </label>
-                            </div>
+                                        <t t-else="">
+                                            <input type="radio" name="donation-type" value="sponsorship" class="card-input-element d-none" checked="checked" />
+                                        </t>
+
+                                        <div class="card h-100 card-body d-flex justify-content-around align-items-center">
+                                            <img class="donation-type__card-icon"
+                                                 src="/crowdfunding_compassion/static/src/img/icn_children.png"/>
+                                            <h4 class="blue text-center uppercase">Sponsor a child</h4>
+                                            <h6 class="blue text-center uppercase">(You will be redirected to compassion switzerland website)</h6>
+
+                                            <!-- Show the select button also if there is a fund option-->
+                                            <t t-if="project.product_id">
+                                                <span class="fake-btn my-3 uppercase">Select</span>
+                                            </t>
+                                        </div>
+                                    </label>
+                                </div>
+                            </t>
 
                             <!-- Project impact card without progress bars -->
                                 <div class="col-sm-12 col-md-4 mb-3">


### PR DESCRIPTION
- Fix query parameters so that correct title is used when joining vs creating
- Hide previous button on the creation form when joining on page 2
- When only a fund is selected, don't display the sponsorship option on the donation page and preselect the fund (Not originally in task)