### PR TITLE
FIX _get_report_values

### DIFF
--- a/report_compassion/models/report_bvr_sponsorship.py
+++ b/report_compassion/models/report_bvr_sponsorship.py
@@ -10,7 +10,6 @@
 
 import logging
 
-from datetime import datetime
 from dateutil.relativedelta import relativedelta
 
 from odoo import fields, api, models, _
@@ -52,6 +51,10 @@ class BvrSponsorship(models.AbstractModel):
         report = self._get_report()
         final_data = self._get_default_data()
         if data:
+            if data.get("date_start") and isinstance(data["date_start"], str):
+                data["date_start"] = fields.Date.from_string(data["date_start"])
+            if data.get("date_stop") and isinstance(data["date_stop"], str):
+                data["date_stop"] = fields.Date.from_string(data["date_stop"])
             final_data.update(data)
             if not docids and data["doc_ids"]:
                 docids = data["doc_ids"]
@@ -63,9 +66,7 @@ class BvrSponsorship(models.AbstractModel):
         months = list()
         while start <= stop:
             months.append(start)
-            start_dt = datetime.strptime(str(start), "%Y-%m-%d")
-            start_dt = start_dt + relativedelta(months=1)
-            start = start_dt.strftime("%Y-%m-%d")
+            start = start + relativedelta(months=1)
 
         sponsorships = self.env["recurring.contract"].browse(docids)
         sponsorships = sponsorships.filtered(


### PR DESCRIPTION
The keys date_start and date_stop can be received, and can be strings but not necessarily. As such cast to a date object when keys are present and are strings. There was several fixes on this function over the last days, hopefully this one handles all scenarios.