### PR TITLE
CO-3316 Fix attempt OG social sharing

### DIFF
--- a/crowdfunding_compassion/models/crowdfunding_project.py
+++ b/crowdfunding_compassion/models/crowdfunding_project.py
@@ -235,4 +235,8 @@ class CrowdfundingProject(models.Model):
         res = super()._default_website_meta()
         res['default_opengraph']['og:description'] = res['default_twitter']['twitter:description'] = self.description
         res['default_opengraph']['og:image'] = res['default_twitter']['twitter:image'] = self.cover_photo_url
+        res['default_opengraph']['og:image:secure_url'] = self.cover_photo_url
+        res['default_opengraph']['og:image:type'] = "image/jpeg"
+        res['default_opengraph']['og:image:width'] = "640"
+        res['default_opengraph']['og:image:height'] = "442"
         return res


### PR DESCRIPTION
Facebook debugger says:

"D’après og:image, vous n’avez pas pu télécharger http://together.compassion.ch/web/content/crowdfunding.project/22/cover_photo. Il peut y avoir différentes raisons à cela, si le serveur ne prend pas en charge l’encodage du contenu par exemple. Le robot d’indexation accepte les encodages deflate et gzip."

However gzip and deflate are enabled and work, so this isn't the problem. I added metatags which might fix this problem, but might not: https://stackoverflow.com/questions/27913369/facebook-open-graph-no-image-first-time/27913458#27913458

If it doesn't, most likely the problem is with the size of the image which will need to be resized server side