### PR TITLE
CO-3333 Fix crowdfunding number agreement

### DIFF
--- a/crowdfunding_compassion/__manifest__.py
+++ b/crowdfunding_compassion/__manifest__.py
@@ -29,7 +29,7 @@
 # pylint: disable=C8101
 {
     "name": "Crowdfunding Compassion",
-    "version": "12.0.1.0.3",
+    "version": "12.0.1.0.4",
     "author": "Compassion CH",
     "license": "AGPL-3",
     "website": "http://www.compassion.ch",

--- a/crowdfunding_compassion/controllers/homepage_controller.py
+++ b/crowdfunding_compassion/controllers/homepage_controller.py
@@ -33,7 +33,7 @@ class HomepageController(Controller):
                 "type": "sponsorship",
                 "value": 0,
                 "name": _("Sponsor children"),
-                "text": _("sponsored children"),
+                "text": _("sponsored child"),
                 "description": _("""
 For 42 francs a month, you're opening the way out of poverty for a child. Sponsorship
  ensures that the child is known, loved and protected. In particular, it gives the child
@@ -51,7 +51,7 @@ For 42 francs a month, you're opening the way out of poverty for a child. Sponso
                 "type": "fund",
                 "value": 0,
                 "name": fund.crowdfunding_impact_text_active,
-                "text": fund.crowdfunding_impact_text_passive,
+                "text": fund.crowdfunding_impact_text_passive_singular,
                 "description": fund.crowdfunding_description,
                 "icon_image": fund.image_medium or sponsor_icon,
                 "header_image": fund.image_large or sponsor_banner,
@@ -63,6 +63,14 @@ For 42 francs a month, you're opening the way out of poverty for a child. Sponso
             project_fund = project.product_id.name
             if project_fund in impact:
                 impact[project_fund]["value"] += project.product_number_reached
+
+        for fund in active_funds:
+            if impact[fund.name]["value"] > 1:
+                impact[fund.name]["text"] = fund.crowdfunding_impact_text_passive_plural
+
+        if impact["sponsorship"]["value"] > 1:
+            impact["sponsorship"]["name"] = _("Sponsor children")
+            impact["sponsorship"]["text"] = _("sponsored children")
 
         return {
             "projects": project_obj.sudo().get_active_projects(limit=6),

--- a/crowdfunding_compassion/controllers/homepage_controller.py
+++ b/crowdfunding_compassion/controllers/homepage_controller.py
@@ -69,7 +69,6 @@ For 42 francs a month, you're opening the way out of poverty for a child. Sponso
                 impact[fund.name]["text"] = fund.crowdfunding_impact_text_passive_plural
 
         if impact["sponsorship"]["value"] > 1:
-            impact["sponsorship"]["name"] = _("Sponsor children")
             impact["sponsorship"]["text"] = _("sponsored children")
 
         return {

--- a/crowdfunding_compassion/controllers/project_controller.py
+++ b/crowdfunding_compassion/controllers/project_controller.py
@@ -85,7 +85,10 @@ class ProjectController(Controller):
                 "type": "donation",
                 "color": "grey",
                 "text": f"{int(donation.quantity)} "
-                f"{donation.product_id.crowdfunding_impact_text_passive}",
+                f"{donation.product_id.crowdfunding_impact_text_passive_plural}"
+                if int(donation.quantity) > 1 else
+                f"{int(donation.quantity)} "
+                f"{donation.product_id.crowdfunding_impact_text_passive_singular}",
                 "image": donation.product_id.image_medium,
                 "benefactor": donation.invoice_id.partner_id.firstname,
                 "date": donation.invoice_id.create_date,

--- a/crowdfunding_compassion/data/products.xml
+++ b/crowdfunding_compassion/data/products.xml
@@ -5,7 +5,8 @@
             <field name="activate_for_crowdfunding" eval="True"/>
             <field name="standard_price">70</field>
             <field name="crowdfunding_description">The Child Survival Program is designed to support pregnant women and their newborns. This fund helps to take care of their health, economic and social needs.</field>
-            <field name="crowdfunding_impact_text_passive">mothers and babies supported</field>
+            <field name="crowdfunding_impact_text_passive_singular">mother and baby supported</field>
+            <field name="crowdfunding_impact_text_passive_plural">mothers and babies supported</field>
             <field name="crowdfunding_impact_text_active">supporting mothers and babies</field>
             <field name="crowdfunding_quantity_singular">mother and baby</field>
             <field name="crowdfunding_quantity_plural">mothers and babies</field>
@@ -19,7 +20,8 @@
             <field name="activate_for_crowdfunding" eval="True"/>
             <field name="standard_price">25</field>
             <field name="crowdfunding_description">38% of the world population does not have daily access to a decent toilet. Compassion is committed to building and sanitizing toilets for children.</field>
-            <field name="crowdfunding_impact_text_passive">access to toilets</field>
+            <field name="crowdfunding_impact_text_passive_singular">access to toilets</field>
+            <field name="crowdfunding_impact_text_passive_plural">access to toilets</field>
             <field name="crowdfunding_impact_text_active">giving access to toilets</field>
             <field name="crowdfunding_quantity_singular">toilet access</field>
             <field name="crowdfunding_quantity_plural">toilet accesses</field>
@@ -33,7 +35,8 @@
             <field name="activate_for_crowdfunding" eval="True"/>
             <field name="standard_price">40</field>
             <field name="crowdfunding_description">To meet the significant costs of this pandemic, our 8,000 partner churches need your support. Every donation, large or small, saves lives and will enable us to provide effective and committed support to sponsored children and their families.</field>
-            <field name="crowdfunding_impact_text_passive">families helped during covid pandemic</field>
+            <field name="crowdfunding_impact_text_passive_singular">family helped during covid pandemic</field>
+            <field name="crowdfunding_impact_text_passive_plural">families helped during covid pandemic</field>
             <field name="crowdfunding_impact_text_active">helping families during covid pandemic</field>
             <field name="crowdfunding_quantity_singular">family</field>
             <field name="crowdfunding_quantity_plural">families</field>

--- a/crowdfunding_compassion/migrations/12.0.1.0.4/post-migration.py
+++ b/crowdfunding_compassion/migrations/12.0.1.0.4/post-migration.py
@@ -1,0 +1,9 @@
+from openupgradelib import openupgrade
+
+
+def migrate(cr, version):
+    if not version:
+        return
+
+    # Force loading products configuration
+    openupgrade.load_xml(cr, "crowdfunding_compassion", "data/products.xml")

--- a/crowdfunding_compassion/models/product_template.py
+++ b/crowdfunding_compassion/models/product_template.py
@@ -14,7 +14,10 @@ class ProductTemplate(models.Model):
     crowdfunding_impact_text_active = fields.Char(
         translate=True, help="Ex: buildling toilets"
     )
-    crowdfunding_impact_text_passive = fields.Char(
+    crowdfunding_impact_text_passive_singular = fields.Char(
+        translate=True, help="Ex: toilet built"
+    )
+    crowdfunding_impact_text_passive_plural = fields.Char(
         translate=True, help="Ex: toilets built"
     )
     fund_selector_pre_description = fields.Char(

--- a/crowdfunding_compassion/templates/crowdfunding_components.xml
+++ b/crowdfunding_compassion/templates/crowdfunding_components.xml
@@ -41,7 +41,12 @@
         <template id="project_progress" name="Project progress">
             <!-- Setup data and display the sponsorship progress -->
             <t t-if="project.number_sponsorships_goal">
-                <t t-set="goal_name">sponsored children</t>
+                <t t-if="project.number_sponsorships_reached > 1">
+                    <t t-set="goal_name">sponsored children</t>
+                </t>
+                <t t-else="">
+                    <t t-set="goal_name">sponsored child</t>
+                </t>
                 <t t-set="goal_reached" t-value="project.number_sponsorships_reached"/>
                 <t t-set="goal_objective" t-value="project.number_sponsorships_goal"/>
                 <t t-set="goal_image" t-value="'/crowdfunding_compassion/static/src/img/icn_children.png'"/>
@@ -50,7 +55,12 @@
 
             <!-- Setup data and display the fund progress -->
             <t t-if="project.product_id">
-                <t t-set="goal_name" t-value="project.product_id.crowdfunding_impact_text_passive"/>
+                <t t-if="project.product_number_reached > 1">
+                    <t t-set="goal_name" t-value="project.product_id.crowdfunding_impact_text_passive_plural"/>
+                </t>
+                <t t-else="">
+                    <t t-set="goal_name" t-value="project.product_id.crowdfunding_impact_text_passive_singular"/>
+                </t>
                 <t t-set="goal_reached" t-value="project.product_number_reached"/>
                 <t t-set="goal_objective" t-value="project.product_number_goal"/>
                 <t t-set="goal_image"
@@ -84,14 +94,24 @@
                     </h4>
 
                     <!-- Setup data and display the sponsorship progress -->
-                    <t t-set="goal_name">sponsored children</t>
+                    <t t-if="participant.number_sponsorships_reached > 1">
+                        <t t-set="goal_name">sponsored children</t>
+                    </t>
+                    <t t-else="">
+                        <t t-set="goal_name">sponsored child</t>
+                    </t>
                     <t t-set="goal_reached" t-value="participant.number_sponsorships_reached"/>
                     <t t-set="goal_objective" t-value="participant.number_sponsorships_goal"/>
                     <t t-set="goal_image" t-value="'/crowdfunding_compassion/static/src/img/icn_children.png'"/>
                     <t t-call="crowdfunding_compassion.goal_progress" t-if="goal_objective"/>
 
                     <!-- Setup data and display the fund progress -->
-                    <t t-set="goal_name" t-value="project.product_id.crowdfunding_impact_text_passive"/>
+                    <t t-if="project.product_number_reached > 1">
+                        <t t-set="goal_name" t-value="project.product_id.crowdfunding_impact_text_passive_plural"/>
+                    </t>
+                    <t t-else="">
+                        <t t-set="goal_name" t-value="project.product_id.crowdfunding_impact_text_passive_singular"/>
+                    </t>
                     <t t-set="goal_reached" t-value="participant.product_number_reached"/>
                     <t t-set="goal_objective" t-value="participant.product_number_goal"/>
                     <t t-set="goal_image"

--- a/crowdfunding_compassion/templates/presentation_page.xml
+++ b/crowdfunding_compassion/templates/presentation_page.xml
@@ -25,16 +25,27 @@
                                         <h3 class="blue my-3 text-center">
                                                 <t t-esc="'Support ' + participant.name"/>
                                             </h3>
+
                                             <div class="project-hero__card-content">
                                                 <!-- Setup data and display the sponsorship progress -->
-                                                <t t-set="goal_name">sponsored children</t>
+                                                <t t-if="participant.number_sponsorships_reached > 1">
+                                                    <t t-set="goal_name">sponsored children</t>
+                                                </t>
+                                                <t t-else="">
+                                                    <t t-set="goal_name">sponsored child</t>
+                                                </t>
                                                 <t t-set="goal_reached" t-value="participant.number_sponsorships_reached"/>
                                                 <t t-set="goal_objective" t-value="participant.number_sponsorships_goal"/>
                                                 <t t-set="goal_image" t-value="'/crowdfunding_compassion/static/src/img/icn_children.png'"/>
                                                 <t t-call="crowdfunding_compassion.goal_progress" t-if="goal_objective"/>
 
                                                 <!-- Setup data and display the fund progress -->
-                                                <t t-set="goal_name" t-value="project.product_id.crowdfunding_impact_text_passive"/>
+                                                <t t-if="project.product_number_reached > 1">
+                                                    <t t-set="goal_name" t-value="project.product_id.crowdfunding_impact_text_passive_plural"/>
+                                                </t>
+                                                <t t-else="">
+                                                    <t t-set="goal_name" t-value="project.product_id.crowdfunding_impact_text_passive_singular"/>
+                                                </t>
                                                 <t t-set="goal_reached" t-value="participant.product_number_reached"/>
                                                 <t t-set="goal_objective" t-value="participant.product_number_goal"/>
                                                 <t t-set="goal_image"

--- a/crowdfunding_compassion/templates/presentation_page.xml
+++ b/crowdfunding_compassion/templates/presentation_page.xml
@@ -25,7 +25,6 @@
                                         <h3 class="blue my-3 text-center">
                                                 <t t-esc="'Support ' + participant.name"/>
                                             </h3>
-
                                             <div class="project-hero__card-content">
                                                 <!-- Setup data and display the sponsorship progress -->
                                                 <t t-if="participant.number_sponsorships_reached > 1">

--- a/crowdfunding_compassion/views/product_view.xml
+++ b/crowdfunding_compassion/views/product_view.xml
@@ -14,7 +14,8 @@
                         <field name="crowdfunding_description"/>
                         <field name="crowdfunding_quantity_singular"/>
                         <field name="crowdfunding_quantity_plural"/>
-                        <field name="crowdfunding_impact_text_passive"/>
+                        <field name="crowdfunding_impact_text_passive_singular"/>
+                        <field name="crowdfunding_impact_text_passive_plural"/>
                         <field name="crowdfunding_impact_text_active"/>
                         <field name="fund_selector_pre_description"/>
                         <field name="fund_selector_post_description"/>


### PR DESCRIPTION
Previously, a number of errors of number agreements throughout the website: sometimes the number was 0 or 1 and the referred name was plural and sometimes there was more than one object and the referred name was singular. This PR tackles all such issues that were discovered so far.
Since some agreements depend on variable computed directly and dynamically in _Python_ code, it was more convenient to replace the `crowdfunding_impact_text_passive` variables by two new ones: one singular and one plural. The equivalent `crowdfunding_impact_text_active` variables stayed untouched since they are used to name sections and are never referred to any type of counting.
Since an _xml_ file containing `no_update="1"` has been modified, all the required files for a migration have been added as well.