### PR TITLE
Fix childpack printing

### DIFF
--- a/partner_communication_switzerland/models/partner_communication.py
+++ b/partner_communication_switzerland/models/partner_communication.py
@@ -336,7 +336,7 @@ class PartnerCommunication(models.Model):
             sponsorships = sponsorships.mapped("sub_sponsorship_id")
         children = sponsorships.mapped("child_id")
         # Always retrieve latest information before printing dossier
-        # children.get_infos()
+        children.get_infos()
         report_name = "report_compassion.childpack_small"
         data = {
             "lang": lang,

--- a/report_compassion/wizards/print_childpack.py
+++ b/report_compassion/wizards/print_childpack.py
@@ -62,6 +62,8 @@ class PrintChildpack(models.TransientModel):
         children = self.env["compassion.child"].browse(
             self.env.context.get("active_ids")
         ).with_context(lang=self.lang)
+        # Always retrieve latest information before printing dossier
+        children.get_infos()
         data = {
             "lang": self.lang,
             "doc_ids": children.ids,


### PR DESCRIPTION
Retrieve latest info before printing children for childpacks again. This error partially comes from #1137, which removes a block code containing the call to `get_infos()` method.