### PR TITLE
CO-3214 replaced language of gift BVR from partner's to correspondent's

### DIFF
--- a/report_compassion/models/contract.py
+++ b/report_compassion/models/contract.py
@@ -51,7 +51,7 @@ class Contract(models.Model):
     @api.multi
     def get_gift_communication(self, product):
         self.ensure_one()
-        lang = self.correspondent_id.lang
+        lang = self.mapped(self.send_gifts_to).lang
         child = self.child_id.with_context(lang=lang)
         born = {
             "en_US": "Born in",

--- a/report_compassion/models/contract.py
+++ b/report_compassion/models/contract.py
@@ -51,7 +51,7 @@ class Contract(models.Model):
     @api.multi
     def get_gift_communication(self, product):
         self.ensure_one()
-        lang = self.partner_id.lang
+        lang = self.correspondent_id.lang
         child = self.child_id.with_context(lang=lang)
         born = {
             "en_US": "Born in",


### PR DESCRIPTION
When printing gift payment slips, switched language from the partner's to the correspondent's.