### PR TITLE
CO-3358 fix datetime conversion in advocates menu

### DIFF
--- a/partner_compassion/models/advocate_details.py
+++ b/partner_compassion/models/advocate_details.py
@@ -154,7 +154,7 @@ class AdvocateDetails(models.Model):
                 ]
             )
             details.number_events = len(details.event_ids)
-            details.last_event = details.event_ids[:1].end_date
+            details.last_event = details.event_ids[:1].end_date.date()
 
     @api.multi
     def _compute_formation(self):


### PR DESCRIPTION
Last event of advocate needs to be either a date or string object. Until now, it was a datetime object. 