### PR TITLE
CO-3367 Line breaks are now reflected on project presentation page

### DIFF
--- a/crowdfunding_compassion/templates/presentation_page.xml
+++ b/crowdfunding_compassion/templates/presentation_page.xml
@@ -126,7 +126,11 @@
                                     <!-- Project description and video -->
                                     <h3 class="blue my-4">About the project</h3>
                                     <p>
-                                        <t t-esc="project.description"/>
+                                        <t t-set="description_lines" t-value="project.description.split('\n')" />
+                                            <t t-foreach="description_lines" t-as="description_line">
+                                                <span t-esc="description_line"/>
+                                                <br />
+                                            </t>
                                     </p>
                                     <t t-if="project.presentation_video_embed">
                                         <iframe class="my-3" width="100%" height="400px" t-att-src="project.presentation_video_embed" frameborder="0"/>


### PR DESCRIPTION
Previously, the characters `\n` were considered as white space inside a `<p></p>` tag. This was problematic for supporters that would create a nice description for their project, and having it reduced to a single big block. A simple conversion of the `\n` to `<br />` was not enough either, because the `<br />` tags ended up appearing in plain text, instead of adding line breaks. For this solution, we construct the field line by line and add a line break at the end of every one of them.