### PR TITLE
CO-3319 Barometer now consider total donations, to prevent roundig errors

### DIFF
--- a/crowdfunding_compassion/models/crowdfunding_project.py
+++ b/crowdfunding_compassion/models/crowdfunding_project.py
@@ -156,7 +156,8 @@ class CrowdfundingProject(models.Model):
     def _compute_product_number_reached(self):
         for project in self:
             invl = project.invoice_line_ids.filtered(lambda l: l.state == "paid")
-            project.product_number_reached = int(sum(invl.mapped("quantity")))
+            project.product_number_reached = int(sum(invl.mapped("price_total")) /
+                                                 project.product_id.standard_price)
 
     @api.multi
     def _compute_number_sponsorships_goal(self):


### PR DESCRIPTION
Instead of making the sum of all number of product by person, the total donations is computed and divided by the price of a product. This prevent rounding errors when displaying.