### PR TITLE
CO-3392 Fix domain for mail activities, set employee field for partners

### DIFF
--- a/partner_compassion/__manifest__.py
+++ b/partner_compassion/__manifest__.py
@@ -29,7 +29,7 @@
 # pylint: disable=C8101
 {
     "name": "Upgrade Partners for Compassion Suisse",
-    "version": "12.0.1.0.0",
+    "version": "12.0.1.0.1",
     "category": "Partner",
     "author": "Compassion CH",
     "license": "AGPL-3",

--- a/partner_compassion/migrations/12.0.1.0.1/pre-migration.py
+++ b/partner_compassion/migrations/12.0.1.0.1/pre-migration.py
@@ -1,0 +1,11 @@
+def migrate(cr, version):
+    if not version:
+        return
+
+    # Update employee field to be correct
+    cr.execute("""
+        UPDATE res_partner
+        SET employee = not res_users.share
+        FROM res_users
+        WHERE res_partner.id = res_users.partner_id;
+    """)

--- a/partner_compassion/models/__init__.py
+++ b/partner_compassion/models/__init__.py
@@ -19,3 +19,4 @@ from . import advocate_engagement
 from . import match_partner
 from . import calendar_attendee
 from . import survey_user_input_line
+from . import mail_activity

--- a/partner_compassion/models/mail_activity.py
+++ b/partner_compassion/models/mail_activity.py
@@ -1,0 +1,20 @@
+##############################################################################
+#
+#    Copyright (C) 2020 Compassion CH (http://www.compassion.ch)
+#    @author: Théo Nikles <theo.nikles@gmail.com>
+#
+#    The licence is in the file __manifest__.py
+#
+##############################################################################
+from odoo import models, fields
+
+
+class MailActivity(models.Model):
+    _inherit = "mail.activity"
+
+    # Override domain to consider only internal users
+    user_id = fields.Many2one(
+        "res.users", "Assigned to",
+        default=lambda self: self.env.user,
+        index=True, required=True,
+        domain="[('share', '=', False)]")

--- a/partner_compassion/models/mail_activity.py
+++ b/partner_compassion/models/mail_activity.py
@@ -14,7 +14,4 @@ class MailActivity(models.Model):
 
     # Override domain to consider only internal users
     user_id = fields.Many2one(
-        "res.users", "Assigned to",
-        default=lambda self: self.env.user,
-        index=True, required=True,
         domain="[('share', '=', False)]")


### PR DESCRIPTION
The domain of the `mail.activities` has been set to consider only the employees of _CompassionCH_. There is a field `employee` inside `res.partner` but that is false for every single record of the database. A migration is also included in this _PR_ to set this field correctly for the employees of the _NGO_.