### PR TITLE
CO-3427 Fixing crowdfunding broken links in specific cases

### DIFF
--- a/crowdfunding_compassion/controllers/projects_controller.py
+++ b/crowdfunding_compassion/controllers/projects_controller.py
@@ -12,7 +12,7 @@ from odoo.http import request, route, Controller, local_redirect
 from odoo.addons.cms_form.controllers.main import FormControllerMixin
 
 from ..forms.project_creation_form import NoGoalException,\
-    NegativeGoalException, InvalidDateException
+    NegativeGoalException, InvalidDateException, InvalidVideoLinkException
 
 
 class ProjectsController(Controller, FormControllerMixin):
@@ -58,15 +58,22 @@ class ProjectsController(Controller, FormControllerMixin):
 
         try:
             project_creation_form.form_process()
+        except InvalidVideoLinkException:
+            request.website.add_status_message(
+                _("The video link you entered is incorrect"), type_="danger"
+            )
         except InvalidDateException:
-            request.website.add_status_message(_("Please select a valid date"),
-                                               type_="danger")
+            request.website.add_status_message(
+                _("Please select a valid date"), type_="danger"
+            )
         except NoGoalException:
-            request.website.add_status_message(_("Please define a goal"),
-                                               type_="danger")
+            request.website.add_status_message(
+                _("Please define a goal"), type_="danger"
+            )
         except NegativeGoalException:
-            request.website.add_status_message(_("Please define a positive goal"),
-                                               type_="danger")
+            request.website.add_status_message(
+                _("Please define a positive goal"), type_="danger"
+            )
         values.update({
             "user": request.env.user,
             "form": project_creation_form,

--- a/crowdfunding_compassion/forms/project_creation_form.py
+++ b/crowdfunding_compassion/forms/project_creation_form.py
@@ -112,7 +112,7 @@ class ProjectCreationWizard(models.AbstractModel):
         if values.get(key):
             url = values[key]
             if not url.startswith("http"):
-                return "http://" + url
+                return "https://" + url
         return None
 
 


### PR DESCRIPTION
There used to be a problem if a user entered a link that did not begin either with `http://` or `https://`. The server would interpret the link as a route and append the address of the server before, e.g. `https://erp.compassion.ch/www.mysite.com`. The `http://` is now forced in such cases.
Also, there was a bug that would make the server return an _error 500_ if the video link did not contain a proper hostname and a path. This is also handle in this _PR_.