### PR TITLE
CO-3206 FIX partner name inversions

### DIFF
--- a/crm_switzerland/models/request.py
+++ b/crm_switzerland/models/request.py
@@ -27,6 +27,8 @@ class CrmClaim(models.Model):
                             "email": email_alias,
                             "contact_id": partner.id,
                             "active": False,
+                            "lastname": partner.lastname,
+                            "firstname": partner.firstname,
                         }
                     )
 

--- a/partner_compassion/models/partner_compassion.py
+++ b/partner_compassion/models/partner_compassion.py
@@ -285,6 +285,36 @@ class ResPartner(models.Model):
             self.compute_geopoint()
         return res
 
+    @api.multi
+    @api.returns(None, lambda value: value[0])
+    def copy_data(self, default=None):
+        """
+        Fix bug changing the firstname and lastname because of automatic name
+        computations. We remove the name value in the copy fields.
+        """
+        res = super().copy_data(default)
+        res[0].pop("name", False)
+        return res
+
+    def _contact_fields(self):
+        """
+        Fix bug changing the firstname and lastname because of automatic name
+        computations. We remove the name value in the contact fields.
+        """
+        res = super()._contact_fields()
+        res.remove("name")
+        return res
+
+    @api.model
+    def _add_missing_default_values(self, values):
+        """
+        Fix bug changing the firstname and lastname because of automatic name
+        computations. We remove the name value in the default values.
+        """
+        res = super()._add_missing_default_values(values)
+        res.pop("name", False)
+        return res
+
     @api.model
     def name_search(self, name, args=None, operator="ilike", limit=80):
         """Extends to use trigram search."""


### PR DESCRIPTION
Fix by forcing lastname and firstname when copying a partner
and removing field name from default values to avoid
a wrong inverse computation