### PR TITLE
CO-3422 Changing communications CRON to automated actions

### DIFF
--- a/partner_communication_switzerland/__manifest__.py
+++ b/partner_communication_switzerland/__manifest__.py
@@ -29,7 +29,7 @@
 # pylint: disable=C8101
 {
     "name": "Compassion CH Partner Communications",
-    "version": "12.0.1.0.3",
+    "version": "12.0.1.0.4",
     "category": "Other",
     "author": "Compassion CH",
     "license": "AGPL-3",
@@ -76,6 +76,7 @@
         "views/download_child_pictures_view.xml",
         "views/end_contract_wizard_view.xml",
         "views/disaster_alert_view.xml",
+        "views/ir_actions_view.xml",
         "views/partner_compassion_view.xml",
         "views/contract_view.xml",
         "views/change_text_wizard_view.xml",

--- a/partner_communication_switzerland/data/sponsorship_communications_cron.xml
+++ b/partner_communication_switzerland/data/sponsorship_communications_cron.xml
@@ -1,44 +1,76 @@
 <odoo>
     <data noupdate="1">
-        <record id="sponsorship_daily_communication_cron" model="ir.cron">
-            <field name="name">Send daily sponsorship communication</field>
-            <field name="interval_number">1</field>
-            <field name="interval_type">days</field>
-            <field name="numbercall">-1</field>
-            <field name="model_id" ref="model_recurring_contract"/>
-            <field name="state">code</field>
-            <field name="code">model.send_daily_communication()</field>
-            <field name="active" eval="False"/>
-        </record>
-        <record id="sponsorship_monthly_communication_cron" model="ir.cron">
-            <field name="name">Send monthly sponsorship communication</field>
-            <field name="interval_number">1</field>
-            <field name="interval_type">months</field>
-            <field name="numbercall">-1</field>
-            <field name="model_id" ref="model_recurring_contract"/>
-            <field name="state">code</field>
-            <field name="code">model.send_monthly_communication()</field>
-            <field name="active" eval="False"/>
-        </record>
-        <record id="sponsorship_reminders_cron" model="ir.cron">
-            <field name="name">Send sponsorship reminders</field>
-            <field name="interval_number">1</field>
-            <field name="interval_type">months</field>
-            <field name="numbercall">-1</field>
-            <field name="model_id" ref="model_recurring_contract"/>
-            <field name="state">code</field>
-            <field name="code">model.send_sponsorship_reminders()</field>
-            <field name="active" eval="False"/>
-        </record>
-        <record id="yearly_tax_receipt_cron" model="ir.cron">
-            <field name="name">Generate tax receipts</field>
-            <field name="interval_number">12</field>
-            <field name="interval_type">months</field>
-            <field name="numbercall">-1</field>
-            <field name="model_id" ref="model_res_partner"/>
-            <field name="state">code</field>
-            <field name="code">model.generate_tax_receipts()</field>
-            <field name="active" eval="False"/>
-        </record>
+        <template>
+            <!-- Reccuring CRONs that cannot be replaced by automated actions -->
+            <record id="sponsorship_daily_communication_cron" model="ir.cron">
+                <field name="name">Send daily sponsorship communication</field>
+                <field name="interval_number">1</field>
+                <field name="interval_type">days</field>
+                <field name="numbercall">-1</field>
+                <field name="model_id" ref="model_recurring_contract"/>
+                <field name="state">code</field>
+                <field name="code">model.send_daily_communication()</field>
+                <field name="active" eval="False"/>
+            </record>
+            <record id="sponsorship_reminders_cron" model="ir.cron">
+                <field name="name">Send sponsorship reminders</field>
+                <field name="interval_number">1</field>
+                <field name="interval_type">months</field>
+                <field name="numbercall">-1</field>
+                <field name="model_id" ref="model_recurring_contract"/>
+                <field name="state">code</field>
+                <field name="code">model.send_sponsorship_reminders()</field>
+                <field name="active" eval="False"/>
+            </record>
+            <record id="yearly_tax_receipt_cron" model="ir.cron">
+                <field name="name">Generate tax receipts</field>
+                <field name="interval_number">12</field>
+                <field name="interval_type">months</field>
+                <field name="numbercall">-1</field>
+                <field name="model_id" ref="model_res_partner"/>
+                <field name="state">code</field>
+                <field name="code">model.generate_tax_receipts()</field>
+                <field name="active" eval="False"/>
+            </record>
+
+            <!-- Sponsorship anniversaries (1, 3, 5, 10 and 15 years) -->
+            <t t-foreach="[1,3,5,10,15]" t-as="year">
+                <t t-set="record_id" t-value="'sponsorship_anniversary_%d_communication' % year"/>
+                <t t-set="record_name" t-value="'Send sponsorship anniversary %d year %s communication' % (year, 's' if year != 1 else '')"/>
+                <t t-set="config_id" t-value="'planned_anniversary_%d' % year"/>
+                <t t-set="date_range" t-value="12 * year"/>
+                <t t-set="min_date" t-value="Datetime.now() + relativedelta(years=years)"/>
+                <!-- Record creation -->
+                <record id="record_id" model="base.automation">
+                    <field name="name">record_name</field>
+                    <field name="model_id" ref="model_recurring_contract"/>
+                    <field name="config_id" ref="config_id"/>
+                    <field name="state">Send Communication</field>
+                    <field name="partner_field">partner_id</field>
+                    <field name="filter_domain">[("start_date", ">=", min_date)]</field>
+                    <field name="trigger">on_time</field>
+                    <field name="trg_date_id">start_date</field>
+                    <field name="trg_date_range">date_range</field>
+                    <field name="trg_date_range_type">month</field>
+                    <field name="active" eval="False"/>
+                </record>
+            </t>
+
+            <!-- Write and pray reminders -->
+            <t t-set="min_date" t-value="Datetime.now() + relativedelta(months=3)"/>
+            <record id="wrpr_sponsorship_reminder" model="base.automation">
+                <field name="name">Write and Pray sponsorship reminder</field>
+                <field name="model_id" ref="model_recurring_contract"/>
+                <field name="config_id" ref="sponsorship_wrpr_reminder"/>
+                <field name="state">Send Communication</field>
+                <field name="partner_field">partner_id</field>
+                <field name="filter_domain">[("activation_date", ">=", min_date)]</field>
+                <field name="trigger">on_time</field>
+                <field name="trg_date_id">activation_date</field>
+                <field name="trg_date_range">3</field>
+                <field name="trg_date_range_type">month</field>
+                <field name="active" eval="False"/>
+            </record>
+        </template>
     </data>
 </odoo>

--- a/partner_communication_switzerland/migrations/12.0.1.0.4/post-migration.py
+++ b/partner_communication_switzerland/migrations/12.0.1.0.4/post-migration.py
@@ -1,0 +1,9 @@
+from openupgradelib import openupgrade
+
+
+def migrate(cr, installed_version):
+    if not installed_version:
+        return
+
+    openupgrade.load_xml(cr, 'partner_communication_switzerland',
+                         'data/sponsorship_communications_cron.xml')

--- a/partner_communication_switzerland/models/__init__.py
+++ b/partner_communication_switzerland/models/__init__.py
@@ -24,3 +24,4 @@ from . import staff_notifications_settings
 from . import sms_child_request
 from . import res_users
 from . import thankyou_config
+from . import ir_actions

--- a/partner_communication_switzerland/models/ir_actions.py
+++ b/partner_communication_switzerland/models/ir_actions.py
@@ -1,0 +1,44 @@
+##############################################################################
+#
+#    Copyright (C) 2020 Compassion CH (http://www.compassion.ch)
+#    @author: Théo Nikles <theo.nikles@gmail.com>
+#
+#    The licence is in the file __manifest__.py
+#
+##############################################################################
+from odoo import models, fields, api
+
+
+class IrActionsServer(models.Model):
+    _inherit = 'ir.actions.server'
+
+    state = fields.Selection(
+        selection_add=[("communication", "Send Communication")]
+    )
+    config_id = fields.Many2one(
+        "partner.communication.config", "Communication type", readonly=False,
+        domain="[('model_id', '=', model_id)]",
+    )
+    partner_field = fields.Char(string="Partner field name")
+
+    @api.model
+    def run_action_communication(self, action, eval_context=None):
+        if not action.config_id or not self._context.get('active_id') or self._is_recompute(action):
+            return False
+
+        comm_job = self.env["partner.communication.job"]
+        communications = self.env["partner.communication.job"]
+        if "records" in eval_context:
+            for record in eval_context["records"]:
+                partner_id = record.mapped(action.partner_field)
+                vals = {
+                    "partner_id": partner_id.id,
+                    "object_ids": record.id,
+                    "config_id": action.config_id.id,
+                    "auto_send": False,
+                }
+                communications += comm_job.create(vals)
+            
+            for communication in communications:
+                communication.send()
+        return False

--- a/partner_communication_switzerland/views/ir_actions_view.xml
+++ b/partner_communication_switzerland/views/ir_actions_view.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+
+        <record model="ir.ui.view" id="view_server_action_form_template_inherit">
+            <field name="name">ir.actions.server.form.inherit</field>
+            <field name="model">ir.actions.server</field>
+            <field name="inherit_id" ref="mail.view_server_action_form_template"/>
+            <field name="arch" type="xml">
+                <field name="link_field_id" position="after">
+                    <field name="config_id"
+                        attrs="{'invisible': [('state', '!=', 'communication')],
+                                'required': [('state', '=', 'communication')]}"/>
+                    <field name="partner_field"
+                        attrs="{'invisible': [('state', '!=', 'communication')],
+                                'required': [('state', '=', 'communication')]}"/>
+                </field>
+            </field>
+        </record>
+    </data>
+</odoo>


### PR DESCRIPTION
The onboarding process relied previously on _CRON_ exclusively. The issue is that a _CRON_ might be complicated to configure and so using _automated actions_ looked promising, as their creation is way easier. Nevertheless, we did not find an easy solution to implement recurrent events with these _automated actions_. So for the moment they are not a viable option to completely replace all existing _CRON_.
Here is a first shot for implementing a new _automated action_, namely "Send Communication", which is configured using a message template, the model on which it applies, the name of the _partner_ field inside the model (`partner_id`, `id`, `sponsor_id`, ...), the domain on which it applies and the trigger condition. The _PR_ also defines two of these automated actions defined in _XML_ files.