### PR TITLE
CO-3318 Making bootstrap themes personalizable through GUI

### DIFF
--- a/theme_compassion/__manifest__.py
+++ b/theme_compassion/__manifest__.py
@@ -29,7 +29,8 @@
 # pylint: disable=C8101
 {
     "name": "Main Compassion Theme",
-    "version": "12.0.1.0.0",
+    "version": "1.0",
+    "category": "Theme",
     "author": "Compassion CH",
     "license": "AGPL-3",
     "website": "http://www.compassion.ch",
@@ -43,8 +44,6 @@
         "views/assets.xml",
         "views/homepage.xml",
     ],
-    'css': ['static/src/scss/custom.scss'],
-    'category': 'Theme',
-    "installable": True,
-    "auto_install": False,
+    "css": ["static/src/scss/custom.scss"],
+    "application": False,
 }

--- a/theme_compassion/models/__init__.py
+++ b/theme_compassion/models/__init__.py
@@ -6,4 +6,4 @@
 #    The licence is in the file __manifest__.py
 #
 ##############################################################################
-from . import models
+from . import theme_compassion

--- a/theme_compassion/models/theme_compassion.py
+++ b/theme_compassion/models/theme_compassion.py
@@ -6,4 +6,11 @@
 #    The licence is in the file __manifest__.py
 #
 ##############################################################################
-from . import models
+from odoo import models
+
+
+class ThemeCompassion(models.AbstractModel):
+    _inherit = 'theme.utils'
+
+    def _theme_compassion_post_copy(self, mod):
+        self.disable_view('website_theme_install.customize_modal')

--- a/theme_crowdfunding/__init__.py
+++ b/theme_crowdfunding/__init__.py
@@ -1,0 +1,9 @@
+##############################################################################
+#
+#    Copyright (C) 2020 Compassion CH (http://www.compassion.ch)
+#    @author: Théo Nikles <theo.nikles@gmail.com>
+#
+#    The licence is in the file __manifest__.py
+#
+##############################################################################
+from . import models

--- a/theme_crowdfunding/__manifest__.py
+++ b/theme_crowdfunding/__manifest__.py
@@ -29,7 +29,8 @@
 # pylint: disable=C8101
 {
     "name": "Crowdfunding Compassion Theme",
-    "version": "12.0.1.0.0",
+    "version": "1.0",
+    "category": "Theme",
     "author": "Compassion CH",
     "license": "AGPL-3",
     "website": "http://www.compassion.ch",
@@ -39,7 +40,5 @@
     "data": [
         "views/assets.xml"
     ],
-    'category': 'Theme',
-    "installable": True,
-    "auto_install": False,
+    "application": False,
 }

--- a/theme_crowdfunding/models/__init__.py
+++ b/theme_crowdfunding/models/__init__.py
@@ -6,4 +6,4 @@
 #    The licence is in the file __manifest__.py
 #
 ##############################################################################
-from . import models
+from . import theme_crowdfunding

--- a/theme_crowdfunding/models/theme_crowdfunding.py
+++ b/theme_crowdfunding/models/theme_crowdfunding.py
@@ -6,4 +6,11 @@
 #    The licence is in the file __manifest__.py
 #
 ##############################################################################
-from . import models
+from odoo import models
+
+
+class ThemeCrowdfunding(models.AbstractModel):
+    _inherit = 'theme.utils'
+
+    def _theme_crowdfunding_post_copy(self, mod):
+        self.disable_view('website_theme_install.customize_modal')


### PR DESCRIPTION
Previously, it was not possible to personalize a theme that you created through _GUI_. This was because a view would overwrite the menu to do such. This _PR_ ignores this overridden view and hence solves the problem.
If the theme is applied to multiple different websites and you change on one of them, the modification will be repercussed on all the other websites that use the same theme. Nevertheless, there is no modification if different websites use different themes. This is the desired behaviour.