### PR TITLE
CO-3479 Miscellaneous fixes and improvements of the crowdfunding platform

### DIFF
--- a/crowdfunding_compassion/forms/project_creation_form.py
+++ b/crowdfunding_compassion/forms/project_creation_form.py
@@ -281,19 +281,12 @@ class ProjectCreationStep2(models.AbstractModel):
         product_goal = extra_values.get('participant_product_number_goal')
         sponsorship_goal = extra_values.get('participant_number_sponsorships_goal')
 
-        # Existing projects with sponsorship and fund chosen must have both
-        if self.main_object:
-            if self.main_object.product_id and \
-                    self.main_object.number_sponsorships_goal:
-                if not product_goal or not sponsorship_goal:
-                    raise NoGoalException
-        else:
-            # New projects must have at least either a sponsorship or a fund objective
-            if not product_goal and not sponsorship_goal:
-                raise NoGoalException
-            elif product_goal and int(product_goal) < 0 or sponsorship_goal and int(
-                    sponsorship_goal) < 0:
-                raise NegativeGoalException
+        # Projects must have either a positive sponsorship or fund objective
+        if not product_goal and not sponsorship_goal:
+            raise NoGoalException
+        elif product_goal and int(product_goal) < 0 or sponsorship_goal and int(
+                sponsorship_goal) < 0:
+            raise NegativeGoalException
 
         if not product_goal:
             values["product_id"] = False

--- a/crowdfunding_compassion/models/crowdfunding_participant.py
+++ b/crowdfunding_compassion/models/crowdfunding_participant.py
@@ -42,6 +42,11 @@ class CrowdfundingParticipant(models.Model):
     profile_photo_url = fields.Char(compute="_compute_profile_photo_url")
     sponsorship_url = fields.Char(compute="_compute_sponsorship_url")
 
+    _sql_constraints = [
+        ('registration_unique', "unique(project_id,partner_id)",
+         "Only one registration per participant/project is allowed!")
+    ]
+
     @api.model
     def create(self, vals):
         partner = self.env["res.partner"].browse(vals.get("partner_id"))

--- a/crowdfunding_compassion/static/src/js/donation_page.js
+++ b/crowdfunding_compassion/static/src/js/donation_page.js
@@ -6,23 +6,38 @@ const radios = document.querySelectorAll('input[type="radio"]');
 const a = document.getElementById("url");
 
 function clickHandler() {
-  let checked_radios = document.querySelectorAll("input[type=radio]:checked").length;
-  submit.disabled = checked_radios == 0 || checked_radios == 1;
+  let participantId = document.querySelector('input[name="participant"]:checked');
+
+  // Enable or disable fund according to the choice of the participant
+  if (participantId && participantId.value) {
+    let products_number = document.querySelector('input[name="product_goal_' +
+      participantId.value + '"]').value;
+    let sponsorships_number = document.querySelector('input[name="sponsorship_goal_' +
+      participantId.value + '"]').value;
+
+    // Used for automatic selection if only one type of support is chosen
+    let select_product = products_number && !sponsorships_number;
+    let select_sponsorship = sponsorships_number && !products_number;
+
+    enableOrDisableDiv("product", products_number, select_product);
+    enableOrDisableDiv("sponsorship", sponsorships_number, select_sponsorship);
+  }
+
+  let donationType = document.querySelector('input[name="donation-type"]:checked');
+
+  submit.disabled = !(donationType && donationType.value &&
+    participantId && participantId.value);
 
   if (!submit.disabled) {
-    let donationType = document.querySelector('input[name="donation-type"]:checked')
-      .value;
-    let participantId = document.querySelector('input[name="participant"]:checked')
-      .value;
-
-    if (donationType === "fund") {
-      a.href = `/project/${a.getAttribute("project")}/donation/form/${participantId}`;
+    if (donationType.value === "product") {
+      a.href = `/project/${a.getAttribute("project")}/donation/form/${participantId.value}`;
       a.target = "";
     }
 
-    if (donationType === "sponsorship") {
-        a.href = document.querySelector('input[name="sponsorship_url"]').value;
-        a.target = "_blank";
+    if (donationType.value === "sponsorship") {
+      a.href = document.querySelector('input[name="sponsorship_url_' +
+        participantId.value + '"]').value;
+      a.target = "_blank";
     }
   }
 }
@@ -32,5 +47,20 @@ radios.forEach((radio) => {
   radio.addEventListener("change", clickHandler);
 });
 
-// Exectute on page load
+// Execute on page load
 clickHandler();
+
+function enableOrDisableDiv(supportType, quantity, autoSelect) {
+  const element = document.getElementById(supportType + "_card");
+  if (quantity && quantity !== "0") {
+    if (autoSelect) {
+        element.querySelector('input[name="donation-type"').checked = true;
+    }
+    element.style.display = "block";
+  } else {
+    // We uncheck elements that are hidden
+    element.querySelector('input[name="donation-type"]').checked = false;
+    element.style.display = "none";
+  }
+  return quantity && quantity !== "0";
+}

--- a/crowdfunding_compassion/templates/crowdfunding_components.xml
+++ b/crowdfunding_compassion/templates/crowdfunding_components.xml
@@ -93,47 +93,47 @@
         <!-- This is a card shown on a project page with a participant personnal progress bars -->
         <!-- Individual [participant] model must be set before calling this template -->
         <template id="participant_card" name="Participant card">
-            <div class="card participants__card">
-                <a t-attf-href="/participant/#{participant.id}">
-                    <div>
-                        <img class="participants__image" t-att-src="participant.profile_photo_url" alt="Participant image" t-if="participant.profile_photo_url"/>
+            <div class="card participants__card mb-4">
+                <div class="h-100">
+                    <a t-attf-href="/participant/#{participant.id}">
+                        <div>
+                            <img class="participants__image" t-att-src="participant.profile_photo_url" alt="Participant image" t-if="participant.profile_photo_url"/>
+                        </div>
+                    </a>
+                    <div class="participants__content">
+                        <h4 class="participants__name">
+                            <a t-attf-href="/participant/#{participant.id}">
+                                <t t-esc="participant.partner_id.name"/>
+                            </a>
+                        </h4>
+
+                        <!-- Setup data and display the sponsorship progress -->
+                        <t t-if="participant.number_sponsorships_reached > 1">
+                            <t t-set="goal_name">sponsored children</t>
+                        </t>
+                        <t t-else="">
+                            <t t-set="goal_name">sponsored child</t>
+                        </t>
+                        <t t-set="goal_reached" t-value="participant.number_sponsorships_reached"/>
+                        <t t-set="goal_objective" t-value="participant.number_sponsorships_goal"/>
+                        <t t-set="goal_image" t-value="'/crowdfunding_compassion/static/src/img/icn_children.png'"/>
+                        <t t-call="crowdfunding_compassion.goal_progress" t-if="goal_objective"/>
+
+                        <!-- Setup data and display the fund progress -->
+                        <t t-if="project.product_number_reached > 1">
+                            <t t-set="goal_name" t-value="project.product_id.crowdfunding_impact_text_passive_plural"/>
+                        </t>
+                        <t t-else="">
+                            <t t-set="goal_name" t-value="project.product_id.crowdfunding_impact_text_passive_singular"/>
+                        </t>
+                        <t t-set="goal_reached" t-value="participant.product_number_reached"/>
+                        <t t-set="goal_objective" t-value="participant.product_number_goal"/>
+                        <t t-set="goal_image"
+                           t-value="participant.project_id.product_id.image_medium or '/crowdfunding_compassion/static/src/img/icn_children.png'"/>
+                        <t t-call="crowdfunding_compassion.goal_progress" t-if="goal_objective"/>
                     </div>
-                </a>
-                <div class="participants__content">
-                    <h4 class="participants__name">
-                        <a t-attf-href="/participant/#{participant.id}">
-                            <t t-esc="participant.partner_id.name"/>
-                        </a>
-                    </h4>
-
-                    <!-- Setup data and display the sponsorship progress -->
-                    <t t-if="participant.number_sponsorships_reached > 1">
-                        <t t-set="goal_name">sponsored children</t>
-                    </t>
-                    <t t-else="">
-                        <t t-set="goal_name">sponsored child</t>
-                    </t>
-                    <t t-set="goal_reached" t-value="participant.number_sponsorships_reached"/>
-                    <t t-set="goal_objective" t-value="participant.number_sponsorships_goal"/>
-                    <t t-set="goal_image" t-value="'/crowdfunding_compassion/static/src/img/icn_children.png'"/>
-                    <t t-call="crowdfunding_compassion.goal_progress" t-if="goal_objective"/>
-
-                    <!-- Setup data and display the fund progress -->
-                    <t t-if="project.product_number_reached > 1">
-                        <t t-set="goal_name" t-value="project.product_id.crowdfunding_impact_text_passive_plural"/>
-                    </t>
-                    <t t-else="">
-                        <t t-set="goal_name" t-value="project.product_id.crowdfunding_impact_text_passive_singular"/>
-                    </t>
-                    <t t-set="goal_reached" t-value="participant.product_number_reached"/>
-                    <t t-set="goal_objective" t-value="participant.product_number_goal"/>
-                    <t t-set="goal_image"
-                       t-value="participant.project_id.product_id.image_medium or '/crowdfunding_compassion/static/src/img/icn_children.png'"/>
-                    <t t-call="crowdfunding_compassion.goal_progress" t-if="goal_objective"/>
                 </div>
-                <a t-attf-href="/project/#{ project.id }/donation/?participant=#{ participant.id }">
-                    <button type="button" class="btn btn-primary mb-4 center">Support</button>
-                </a>
+                <a t-attf-href="/project/#{ project.id }/donation/?participant=#{ participant.id }" class="btn btn-primary btn-block mb-3">Support</a>
             </div>
         </template>
 

--- a/crowdfunding_compassion/templates/presentation_page.xml
+++ b/crowdfunding_compassion/templates/presentation_page.xml
@@ -66,7 +66,7 @@
                                         </div>
                                         <div class="project-hero__card-cta">
                                             <t t-if="project.deadline >= datetime.date.today()">
-                                                <a t-attf-href="/project/#{ project.id }/donation">
+                                                <a t-attf-href="/project/#{ project.id }/donation/?participant=#{ participant.id }">
                                                     <button type="button" class="btn btn-primary btn-lg btn-block mb-2">Donate now</button>
                                                 </a>
                                                 <a t-if="project.type == 'collective'" t-attf-href="/projects/join/#{project.id}">

--- a/crowdfunding_compassion/templates/project_creation_page.xml
+++ b/crowdfunding_compassion/templates/project_creation_page.xml
@@ -182,7 +182,7 @@
                                     <span>Indicate the amount in the above box. 1</span>
                                     <span t-esc="product.crowdfunding_quantity_singular"/>
                                     <span>is equivalent to CHF</span>
-                                    <span t-esc="product.standard_price"/>.-
+                                    <span t-esc="int(product.standard_price)"/>.-
                                 </p>
                             </div>
                         </t>

--- a/crowdfunding_compassion/templates/project_donation_form_page.xml
+++ b/crowdfunding_compassion/templates/project_donation_form_page.xml
@@ -78,12 +78,12 @@
             </xpath>
         </template>
 
-        <!-- Displayed after sucessful payment by [EventsController] -->
+        <!-- Displayed after successful payment by [EventsController] -->
         <template id="donation_successful" name="Crowdfunding donation success">
             <t t-call="crowdfunding_compassion.layout">
                 <section>
                     <div class="jumbotron center-page mt-5">
-                        <h1>Donation Succesful</h1>
+                        <h1>Donation Successful</h1>
                         <p>Thank you! Your donation helps release children from poverty!</p>
                         <a href="/homepage">
                             <button class="btn btn-primary">Back to Homepage</button>

--- a/crowdfunding_compassion/templates/project_donation_page.xml
+++ b/crowdfunding_compassion/templates/project_donation_page.xml
@@ -12,18 +12,18 @@
                         <h1 class="hero-title">I want to</h1>
                         <h5 class="text-white text-uppercase">Select your type of support</h5>
                         <h5 class="text-white text-uppercase">Below, select which person you support</h5>
-                        <div class="row pb-5">
-                            <!-- Fund selectable card -->
-                            <!-- Show fund option only if one is selected -->
+                        <div id="sponsorship_product_cards" class="row pb-5">
+                            <!-- Product selectable card -->
+                            <!-- Show product option only if one is selected -->
                             <t t-if="project.product_id">
-                                <div class="col-sm-12 col-md-4 mb-3">
+                                <div id="product_card" class="col-sm-12 col-md-4 mb-3">
                                     <label class="h-100 w-100">
-                                        <!-- If there is no sponsorship, select fund by default -->
+                                        <!-- If there is no sponsorship, select product by default -->
                                         <t t-if="project.number_sponsorships_goal">
-                                            <input type="radio" name="donation-type" value="fund" class="card-input-element d-none" />
+                                            <input type="radio" name="donation-type" value="product" class="card-input-element d-none" />
                                         </t>
                                         <t t-else="">
-                                            <input type="radio" name="donation-type" value="fund" class="card-input-element d-none" checked="checked" />
+                                            <input type="radio" name="donation-type" value="product" class="card-input-element d-none" checked="checked" />
                                         </t>
 
                                         <div class="card h-100 card-body d-flex justify-content-around align-items-center">
@@ -42,7 +42,7 @@
 
                             <!-- Sponsorship selectable card -->
                             <t t-if="project.number_sponsorships_goal">
-                                <div class="col-sm-12 col-md-4 mb-3">
+                                <div id="sponsorship_card" class="col-sm-12 col-md-4 mb-3">
                                     <label class="h-100 w-100">
                                         <!-- If there is no product id, select sponsorship by default -->
                                         <t t-if="project.product_id">
@@ -58,7 +58,7 @@
                                             <h4 class="blue text-center uppercase">Sponsor a child</h4>
                                             <h6 class="blue text-center uppercase">(You will be redirected to compassion switzerland website)</h6>
 
-                                            <!-- Show the select button also if there is a fund option-->
+                                            <!-- Show the select button also if there is a product option-->
                                             <t t-if="project.product_id">
                                                 <span class="fake-btn my-3 uppercase">Select</span>
                                             </t>
@@ -68,12 +68,12 @@
                             </t>
 
                             <!-- Project impact card without progress bars -->
-                                <div class="col-sm-12 col-md-4 mb-3">
-                                    <a t-attf-href="/project/#{project.id}">
-                                        <t t-set="display_impact" t-value="False" />
-                                        <t t-call="crowdfunding_compassion.project_impact_card" />
-                                    </a>
-                                </div>
+                            <div class="col-sm-12 col-md-4 mb-3">
+                                <a t-attf-href="/project/#{project.id}">
+                                    <t t-set="display_impact" t-value="False"/>
+                                    <t t-call="crowdfunding_compassion.project_impact_card"/>
+                                </a>
+                            </div>
                         </div>
                     </div>
                 </section>
@@ -90,14 +90,16 @@
                                     <t t-if="selected_participant and int(selected_participant) == participant.id">
                                         <input type="radio" name="participant" class="card-input-element d-none" t-att-value="participant.id" checked="checked"/>
                                     </t>
-                                    <t t-if="selected_participant is None and len(project.participant_ids) == 1">
+                                    <t t-elif="selected_participant is None and len(project.participant_ids) == 1">
                                         <input type="radio" name="participant" class="card-input-element d-none" t-att-value="participant.id" checked="checked"/>
                                     </t>
                                     <t t-else="">
                                         <input type="radio" name="participant" class="card-input-element d-none" t-att-value="participant.id"/>
                                     </t>
                                     <t t-call="crowdfunding_compassion.participant_picture" />
-                                    <input name="sponsorship_url" type="hidden" t-att-value="participant.sponsorship_url"/>
+                                    <input t-att-name="'sponsorship_url_%s' % participant.id" type="hidden" t-att-value="participant.sponsorship_url"/>
+                                    <input t-att-name="'sponsorship_goal_%s' % participant.id" type="hidden" t-att-value="participant.number_sponsorships_goal"/>
+                                    <input t-att-name="'product_goal_%s' % participant.id" type="hidden" t-att-value="participant.product_number_goal"/>
                                 </label>
                             </t>
                         </div>


### PR DESCRIPTION
The base task was to allow a user to join a _Crowdfunding_ project without defining a goal for the two support types. While working on this task, numerous small bugs, visual problems and typos were discovered. All that was found has been fixed and can be found listed here:
- When you wanted to join a project, there is a screen that presents the products that can be selected. A price is given in Swiss francs and the amount of _X_ CHF was given as "_X.0.-_" instead of "_X.-_"
- There was a typo with the word _successfully_, written instead _succesfully_
- The buttons _Support_ on the card of participant, on a project page, were not aligned
- When you clicked that same _Support_ button, the participant was not automatically selected and it was not possible to do so
- A participant could join a project multiple times, thus breaking the project as trying to load it lead to _Expected singleton_ errors
- The wrong sponsorship link was provided when you selected another user (it was always the link of the organizer of the event)
- It was not possible for a participant joining a project to choose either sponsorships or products but not both
- After allowing a participant to use only one, it was necessary to display only the right support types in the _GUI_ on the donation page
All these points are addressed by the following _PR_.