### PR TITLE
CO-3480 Changing route /my/home for the future new my_account (still empty)

### DIFF
--- a/crowdfunding_compassion/__manifest__.py
+++ b/crowdfunding_compassion/__manifest__.py
@@ -37,6 +37,7 @@
         "cms_form_compassion",  # compassion-modules
         "theme_crowdfunding",  # compassion-switzerland
         "partner_communication_switzerland",  # compassion-switzerland
+        "website_compassion",  # compassion-switzerland
         "crm_compassion",  # compassion-modules
         "event",  # odoo base modules
         "wordpress_configuration",  # compassion-modules
@@ -59,6 +60,7 @@
         "templates/crowdfunding_components.xml",
         "templates/crowdfunding_form_template.xml",
         "templates/homepage.xml",
+        "templates/my_account_crowdfunding.xml",
         "templates/myaccount_components.xml",
         "templates/myaccount_crowdfunding_page.xml",
         "templates/project_creation_page.xml",

--- a/crowdfunding_compassion/templates/my_account_crowdfunding.xml
+++ b/crowdfunding_compassion/templates/my_account_crowdfunding.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <data>
+        <template id="crowdfunding_page_template" name="Together">
+            <t t-call="website_compassion.my_account_layout">
+                <div class="container m64">
+                    This will be the Crowdfunding view
+                </div>
+            </t>
+        </template>
+
+        <record id="crowdfunding_page" model="website.page">
+            <field name="website_published">True</field>
+            <field name="url">/my/home/together</field>
+            <field name="view_id" ref="crowdfunding_compassion.crowdfunding_page_template"/>
+        </record>
+
+        <template id="my_account_crowdfunding" name="My account Crowdfunding" inherit_id="website_compassion.my_account_layout">
+            <xpath expr="//ul/li[4]" position="after">
+                <t t-if="request.session.get('uid') and request.env.user.partner_id.crowdfunding_project_count">
+                    <li class="nav-item">
+                        <a class="nav-link" href="/my/home/together">Together</a>
+                    </li>
+                </t>
+            </xpath>
+        </template>
+    </data>
+</odoo>

--- a/crowdfunding_compassion/templates/my_account_crowdfunding.xml
+++ b/crowdfunding_compassion/templates/my_account_crowdfunding.xml
@@ -11,7 +11,7 @@
 
         <record id="crowdfunding_page" model="website.page">
             <field name="website_published">True</field>
-            <field name="url">/my/home/together</field>
+            <field name="url">/my/together</field>
             <field name="view_id" ref="crowdfunding_compassion.crowdfunding_page_template"/>
         </record>
 

--- a/crowdfunding_compassion/templates/my_account_crowdfunding.xml
+++ b/crowdfunding_compassion/templates/my_account_crowdfunding.xml
@@ -19,7 +19,7 @@
             <xpath expr="//ul/li[4]" position="after">
                 <t t-if="request.session.get('uid') and request.env.user.partner_id.crowdfunding_project_count">
                     <li class="nav-item">
-                        <a class="nav-link" href="/my/home/together">Together</a>
+                        <a class="nav-link" href="/my/together">Together</a>
                     </li>
                 </t>
             </xpath>

--- a/muskathlon/__manifest__.py
+++ b/muskathlon/__manifest__.py
@@ -62,6 +62,7 @@
         "templates/muskathlon_registration_form.xml",
         "templates/muskathlon_views.xml",
         "templates/muskathlon_order_material.xml",
+        "templates/my_account_muskathlon.xml",
         "templates/assets.xml",
     ],
     "depends": [

--- a/muskathlon/controllers/main.py
+++ b/muskathlon/controllers/main.py
@@ -50,90 +50,9 @@ class MuskathlonWebsite(EventsController, CustomerPortal):
 
     @route(["/my", "/my/home"], type="http", auth="user", website=True)
     def account(self, form_id=None, **kw):
-        """ Inject data for forms. """
-        values = self._prepare_portal_layout_values()
-        partner = values["partner"]
-        advocate_details_id = partner.advocate_details_id.id
-        registration = partner.registration_ids[:1]
-        form_success = False
-
-        # Load forms
-        kw["form_model_key"] = "cms.form.muskathlon.trip.information"
-        trip_info_form = self.get_form("event.registration", registration.id, **kw)
-        if form_id is None or form_id == trip_info_form.form_id:
-            trip_info_form.form_process()
-            form_success = trip_info_form.form_success
-
-        kw["form_model_key"] = "cms.form.partner.coordinates"
-        coordinates_form = self.get_form("res.partner", partner.id, **kw)
-        if form_id is None or form_id == coordinates_form.form_id:
-            coordinates_form.form_process()
-            form_success = coordinates_form.form_success
-
-        kw["form_model_key"] = "cms.form.advocate.details"
-        about_me_form = self.get_form("advocate.details", advocate_details_id, **kw)
-        if form_id is None or form_id == about_me_form.form_id:
-            about_me_form.form_process()
-            form_success = about_me_form.form_success
-
-        kw["form_model_key"] = "cms.form.muskathlon.large.picture"
-        large_picture_form = self.get_form(
-            "advocate.details", advocate_details_id, **kw
-        )
-        if form_id is None or form_id == large_picture_form.form_id:
-            large_picture_form.form_process()
-            form_success = large_picture_form.form_success
-
-        kw["form_model_key"] = "cms.form.muskathlon.passport"
-        passport_form = self.get_form("event.registration", registration.id, **kw)
-        if form_id is None or form_id == passport_form.form_id:
-            passport_form.form_process()
-            form_success = passport_form.form_success
-
-        kw["form_model_key"] = "cms.form.muskathlon.flight.details"
-        kw["registration_id"] = registration.id
-        flight_type = kw.get("flight_type")
-        kw["flight_type"] = "outbound"
-        flight = registration.flight_ids.filtered(lambda f: f.flight_type == "outbound")
-        outbound_flight_form = self.get_form("event.flight", flight.id, **kw)
-        if form_id is None or (
-                form_id == outbound_flight_form.form_id
-                and (not flight_type or flight_type == "outbound")
-        ):
-            outbound_flight_form.form_process(**kw)
-            form_success = outbound_flight_form.form_success
-        kw["flight_type"] = "return"
-        flight = registration.flight_ids.filtered(lambda f: f.flight_type == "return")
-        return_flight_form = self.get_form("event.flight", flight.id, **kw)
-        if form_id is None or (
-                form_id == return_flight_form.form_id
-                and (not flight_type or flight_type == "return")
-        ):
-            return_flight_form.form_process(**kw)
-            form_success = return_flight_form.form_success
-
-        values.update(
-            {
-                "trip_info_form": trip_info_form,
-                "coordinates_form": coordinates_form,
-                "about_me_form": about_me_form,
-                "large_picture_form": large_picture_form,
-                "passport_form": passport_form,
-                "outbound_flight_form": outbound_flight_form,
-                "return_flight_form": return_flight_form,
-            }
-        )
-        values.update(kw)
-        if "registrations" not in values.keys():
-            registrations_array = []
-            for reg in partner.registration_ids:
-                registrations_array.append(reg)
-            values['registrations'] = registrations_array
-        # This fixes an issue that forms fail after first submission
-        if form_success:
-            result = request.redirect("/my/home")
-        else:
-            result = request.render("muskathlon.custom_portal_my_home", values)
+        if not request.session.get('uid'):
+            return request.redirect("/web/login?redirect=/my/home")
+        result = request.render("website_compassion.my_account_layout", {})
         return self._form_redirect(result, full_page=True)
 
     @route(["/my/api"], type="http", auth="user", website=True)

--- a/muskathlon/templates/muskathlon_my_home.xml
+++ b/muskathlon/templates/muskathlon_my_home.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
     <template id="custom_portal_my_home" name="Custom My Portal">
-        <t t-call="portal.frontend_layout">
+        <t t-call="website_compassion.my_account_layout">
             <!-- hides navbar from my portal -->
             <style>.o_portal.container { display: none !important; }</style>
 
             <!-- Page content -->
-            <div id="muskathlon_my_home" class="container mb64">
+            <div id="muskathlon_my_home" class="container">
                 <!-- Load modals for forms -->
                 <t t-call="cms_form_compassion.modal_form">
                     <t t-set="form" t-value="coordinates_form"/>

--- a/muskathlon/templates/my_account_muskathlon.xml
+++ b/muskathlon/templates/my_account_muskathlon.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <data>
+        <template id="muskathlon_page_template" name="Muskathlon">
+            <t t-call="website_compassion.my_account_layout">
+                <div class="container m64">
+                    This will be the Muskathlon view
+                </div>
+            </t>
+        </template>
+
+        <record id="muskathlon_page" model="website.page">
+            <field name="website_published">True</field>
+            <field name="url">/my/home/muskathlon</field>
+            <field name="view_id" ref="muskathlon.muskathlon_page_template"/>
+        </record>
+
+        <template id="my_account_muskathlon" name="My Account Muskathlon" inherit_id="website_compassion.my_account_layout">
+            <xpath expr="//ul/li[4]" position="after">
+                <t t-if="request.session.get('uid') and request.env.user.partner_id.muskathlon_participant_id">
+                    <li class="nav-item">
+                        <a class="nav-link" href="/my/home/muskathlon">Muskathlon</a>
+                    </li>
+                </t>
+            </xpath>
+        </template>
+    </data>
+</odoo>

--- a/muskathlon/templates/my_account_muskathlon.xml
+++ b/muskathlon/templates/my_account_muskathlon.xml
@@ -11,7 +11,7 @@
 
         <record id="muskathlon_page" model="website.page">
             <field name="website_published">True</field>
-            <field name="url">/my/home/muskathlon</field>
+            <field name="url">/my/muskathlon</field>
             <field name="view_id" ref="muskathlon.muskathlon_page_template"/>
         </record>
 

--- a/muskathlon/templates/my_account_muskathlon.xml
+++ b/muskathlon/templates/my_account_muskathlon.xml
@@ -19,7 +19,7 @@
             <xpath expr="//ul/li[4]" position="after">
                 <t t-if="request.session.get('uid') and request.env.user.partner_id.muskathlon_participant_id">
                     <li class="nav-item">
-                        <a class="nav-link" href="/my/home/muskathlon">Muskathlon</a>
+                        <a class="nav-link" href="/my/muskathlon">Muskathlon</a>
                     </li>
                 </t>
             </xpath>

--- a/website_compassion/__manifest__.py
+++ b/website_compassion/__manifest__.py
@@ -35,11 +35,17 @@
     "license": "AGPL-3",
     "website": "http://www.compassion.ch",
     "data": [
+        "template/my_account_components.xml",
+        "template/my_account_personal_info.xml",
+        "template/my_account_payments.xml",
+        "template/my_account_my_children.xml",
+        "template/my_account_write_a_letter.xml",
         "views/robots.xml"
     ],
     "depends": [
         "theme_compassion",  # compassion-switzerland
         "cms_form_compassion",  # compassion-modules
+        "partner_compassion",  # compassion-switzerland
         "partner_contact_in_several_companies",  # OCA/partner_contact
     ],
     "demo": [],

--- a/website_compassion/readme/CONTRIBUTORS.rst
+++ b/website_compassion/readme/CONTRIBUTORS.rst
@@ -1,2 +1,3 @@
 * Sebastien Toth <popod@me.com>
 * Christopher Meier <dev@c-meier.ch>
+* Théo Nikles <theo.nikles@gmail.com>

--- a/website_compassion/template/my_account_components.xml
+++ b/website_compassion/template/my_account_components.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <data>
+        <template id="my_account_layout" name="My Account layout">
+            <t t-call="portal.frontend_layout">
+                <!-- hides navbar from my portal -->
+                <style>.o_portal.container { display: none !important; }</style>
+
+                <nav class="navbar navbar-expand-md navbar-light bg-light">
+                    <div id="my_account_div" class="container">
+                        <div class="collapse navbar-collapse" id="top_menu_collapse">
+                            <ul class="nav navbar-nav mr-auto text-left">
+                                <li class="nav-item">
+                                    <a class="nav-link" href="/my/home/personal_info">Personal information</a>
+                                </li>
+                                <li class="nav-item">
+                                    <a class="nav-link" href="/my/home/my_children">My children</a>
+                                </li>
+                                <li class="nav-item">
+                                    <a class="nav-link" href="/my/home/payments">Payments / Invoicing</a>
+                                </li>
+                                <li class="nav-item">
+                                    <a class="nav-link" href="/my/home/write_a_letter">Write a letter</a>
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+                </nav>
+                <t t-raw="0"/>
+            </t>
+        </template>
+    </data>
+</odoo>

--- a/website_compassion/template/my_account_components.xml
+++ b/website_compassion/template/my_account_components.xml
@@ -20,7 +20,7 @@
                                     <a class="nav-link" href="/my/donations">Payments / Invoicing</a>
                                 </li>
                                 <li class="nav-item">
-                                    <a class="nav-link" href="/my/home/write_a_letter">Write a letter</a>
+                                    <a class="nav-link" href="/my/write_a_letter">Write a letter</a>
                                 </li>
                             </ul>
                         </div>

--- a/website_compassion/template/my_account_components.xml
+++ b/website_compassion/template/my_account_components.xml
@@ -17,7 +17,7 @@
                                     <a class="nav-link" href="/my/children">My children</a>
                                 </li>
                                 <li class="nav-item">
-                                    <a class="nav-link" href="/my/home/payments">Payments / Invoicing</a>
+                                    <a class="nav-link" href="/my/donations">Payments / Invoicing</a>
                                 </li>
                                 <li class="nav-item">
                                     <a class="nav-link" href="/my/home/write_a_letter">Write a letter</a>

--- a/website_compassion/template/my_account_components.xml
+++ b/website_compassion/template/my_account_components.xml
@@ -11,7 +11,7 @@
                         <div class="collapse navbar-collapse" id="top_menu_collapse">
                             <ul class="nav navbar-nav mr-auto text-left">
                                 <li class="nav-item">
-                                    <a class="nav-link" href="/my/home/personal_info">Personal information</a>
+                                    <a class="nav-link" href="/my/personal_info">Personal information</a>
                                 </li>
                                 <li class="nav-item">
                                     <a class="nav-link" href="/my/home/my_children">My children</a>

--- a/website_compassion/template/my_account_components.xml
+++ b/website_compassion/template/my_account_components.xml
@@ -14,7 +14,7 @@
                                     <a class="nav-link" href="/my/personal_info">Personal information</a>
                                 </li>
                                 <li class="nav-item">
-                                    <a class="nav-link" href="/my/home/my_children">My children</a>
+                                    <a class="nav-link" href="/my/children">My children</a>
                                 </li>
                                 <li class="nav-item">
                                     <a class="nav-link" href="/my/home/payments">Payments / Invoicing</a>

--- a/website_compassion/template/my_account_my_children.xml
+++ b/website_compassion/template/my_account_my_children.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <data>
+        <template id="my_children_page_template" name="My children">
+            <t t-call="website_compassion.my_account_layout">
+                <div class="container m64">
+                    This will be my children view
+                </div>
+            </t>
+        </template>
+
+        <record id="my_children_page" model="website.page">
+            <field name="website_published">True</field>
+            <field name="url">/my/home/my_children</field>
+            <field name="view_id" ref="website_compassion.my_children_page_template"/>
+        </record>
+    </data>
+</odoo>

--- a/website_compassion/template/my_account_my_children.xml
+++ b/website_compassion/template/my_account_my_children.xml
@@ -11,7 +11,7 @@
 
         <record id="my_children_page" model="website.page">
             <field name="website_published">True</field>
-            <field name="url">/my/home/my_children</field>
+            <field name="url">/my/children</field>
             <field name="view_id" ref="website_compassion.my_children_page_template"/>
         </record>
     </data>

--- a/website_compassion/template/my_account_payments.xml
+++ b/website_compassion/template/my_account_payments.xml
@@ -11,7 +11,7 @@
 
         <record id="payments_page" model="website.page">
             <field name="website_published">True</field>
-            <field name="url">/my/home/payments</field>
+            <field name="url">/my/donations</field>
             <field name="view_id" ref="website_compassion.payments_page_template"/>
         </record>
     </data>

--- a/website_compassion/template/my_account_payments.xml
+++ b/website_compassion/template/my_account_payments.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <data>
+        <template id="payments_page_template" name="Payments / Invoicing">
+            <t t-call="website_compassion.my_account_layout">
+                <div class="container m64">
+                    This will be the payments view
+                </div>
+            </t>
+        </template>
+
+        <record id="payments_page" model="website.page">
+            <field name="website_published">True</field>
+            <field name="url">/my/home/payments</field>
+            <field name="view_id" ref="website_compassion.payments_page_template"/>
+        </record>
+    </data>
+</odoo>

--- a/website_compassion/template/my_account_personal_info.xml
+++ b/website_compassion/template/my_account_personal_info.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <data>
+        <template id="personal_info_page_template" name="Personal information">
+            <t t-call="website_compassion.my_account_layout">
+                <div class="container m64">
+                    This will be the personal info view
+                </div>
+            </t>
+        </template>
+
+        <record id="personal_info_page" model="website.page">
+            <field name="website_published">True</field>
+            <field name="url">/my/home/personal_info</field>
+            <field name="view_id" ref="website_compassion.personal_info_page_template"/>
+        </record>
+    </data>
+</odoo>

--- a/website_compassion/template/my_account_personal_info.xml
+++ b/website_compassion/template/my_account_personal_info.xml
@@ -11,7 +11,7 @@
 
         <record id="personal_info_page" model="website.page">
             <field name="website_published">True</field>
-            <field name="url">/my/home/personal_info</field>
+            <field name="url">/my/personal_info</field>
             <field name="view_id" ref="website_compassion.personal_info_page_template"/>
         </record>
     </data>

--- a/website_compassion/template/my_account_write_a_letter.xml
+++ b/website_compassion/template/my_account_write_a_letter.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <data>
+        <template id="write_a_letter_page_template" name="Write a letter">
+            <t t-call="website_compassion.my_account_layout">
+                <div class="container m64">
+                    This will be the write a letter view
+                </div>
+            </t>
+        </template>
+
+        <record id="write_a_letter_page" model="website.page">
+            <field name="website_published">True</field>
+            <field name="url">/my/home/write_a_letter</field>
+            <field name="view_id" ref="website_compassion.write_a_letter_page_template"/>
+        </record>
+    </data>
+</odoo>

--- a/website_compassion/template/my_account_write_a_letter.xml
+++ b/website_compassion/template/my_account_write_a_letter.xml
@@ -11,7 +11,7 @@
 
         <record id="write_a_letter_page" model="website.page">
             <field name="website_published">True</field>
-            <field name="url">/my/home/write_a_letter</field>
+            <field name="url">/my/write_a_letter</field>
             <field name="view_id" ref="website_compassion.write_a_letter_page_template"/>
         </record>
     </data>


### PR DESCRIPTION
This is a first shot at the future _My Account_ feature implementation. No graphical work has been done, but the core functionality is supposed to work properly. By default, four tabs are displayed, namely:
- My personal information
- My children
- Payments / invoicing
- Write a letter
If the logged in user participates to a Muskathlon or a Together project, the corresponding tab(s) will appear and the user will be able to see the corresponding data.
If the user is not connected when trying to access _/my/home_, then the login screen is prompted and the user is redirected after the login to the desired page. These redirections need to be improved (a user that participates to no crowdfunding project can still reach the link _/my/home/together_, even though he should not be able). Also, all the links of the form _/my/home/..._ do not require the user to be connected if hard typed in the browser.