### PR TITLE
CO-3485 Adding children's pictures in the view, with download link

### DIFF
--- a/website_compassion/controllers/my_account.py
+++ b/website_compassion/controllers/my_account.py
@@ -6,8 +6,118 @@
 #    The licence is in the file __manifest__.py
 #
 ##############################################################################
+from os import path, remove
+from zipfile import ZipFile
+from urllib.request import urlretrieve, urlopen
+
 from odoo.http import request, route
-from odoo.addons.cms_form_compassion.controllers.payment_controller import PaymentFormController
+from odoo.addons.web.controllers.main import content_disposition
+from odoo.addons.cms_form_compassion.controllers.payment_controller import (
+    PaymentFormController
+)
+
+
+def _get_user_children():
+    """
+    Find all the children for which the connected user has a contract.
+    :return: a recordset of child.compassion which the connected user sponsors
+    """
+    partner = request.env.user.partner_id
+    return (
+        partner.contracts_fully_managed +
+        partner.contracts_correspondant +
+        partner.contracts_paid
+    ).mapped("child_id").sorted("preferred_name")
+
+
+def _fetch_images_from_child(child):
+    """
+    Pass through the pictures of the child given as parameter and fills up a
+    list of tuples of the form (image, full_path). Here, image is a record and
+    full_path is the complete path of the image in the future archive.
+    :param child: the child for which we want to create the image list
+    :return: a list of tuples of the form (image, full_path)
+    """
+    images = []
+    for image in child.pictures_ids:
+        ext = image.image_url.split(".")[-1]
+        filename = f"{child.preferred_name}_" \
+                   f"{image.date}_{child.code}.{ext}"
+        folder = f"{child.preferred_name}_{child.code}"
+        full_path = path.join(folder, filename)
+        images.append((image, full_path))
+    return images
+
+
+def _create_archive(images, archive_name):
+    """
+    Create an archive from a list of images and the name of the future archive.
+    Some files are created locally but are deleted after they are used by the
+    method.
+    :param images: a list of tuples of the form [(image1, full_path1), ...]
+    :param archive_name: the name of the future archive
+    :return: a response for the client to download the created archive
+    """
+    with ZipFile(archive_name, 'w') as archive:
+        for (img, full_path) in images:
+            filename = path.basename(full_path)
+
+            # Create file, write to archive and delete it from os
+            urlretrieve(img.image_url, filename)
+            archive.write(filename, full_path)
+            remove(filename)
+
+    # Get binary content of the archive, then delete the latter
+    archive = open(archive_name, "rb")
+    zip_data = archive.read()
+    archive.close()
+    remove(archive_name)
+
+    return request.make_response(
+        zip_data,
+        [("Content-Type", "application/zip"),
+         ("Content-Disposition", content_disposition(archive_name))]
+    )
+
+
+def _download_image(type, obj_id, child_id):
+    """
+    Download one or multiple images (in a .zip archive if more than one) and
+    return a response for the user to download it.
+    :param type: the type of download, either 'single', 'multiple' or 'all'
+    :param obj_id: the id of the image to download or None
+    :param child_id: the id of the child to download from or None
+    :return: A response for the user to download a single image or an archive
+    containing multiples
+    """
+    if type == "all":  # We want to download all the images of all children
+        children = _get_user_children()
+        images = []
+        for child in children:
+            images += _fetch_images_from_child(child)
+        return _create_archive(images, f"my_children_pictures.zip")
+
+    child = request.env["compassion.child"].browse(int(child_id))
+
+    if type == "multiple":  # We want to download all images from one child
+        return _create_archive(
+            _fetch_images_from_child(child),
+            f"{child.preferred_name}_{child.code}.zip"
+        )
+
+    if type == "single":  # We want to download a single image from a child
+        image = request.env["compassion.child.pictures"].browse(int(obj_id))
+
+        # We get the extension and the binary content from URL
+        ext = image.image_url.split(".")[-1]
+        data = urlopen(image.image_url).read()
+        filename = f"{child.preferred_name}_{image.date}.{ext}"
+
+        return request.make_response(
+            data,
+            [("Content-Type", f"image/{ext}"),
+             ("Content-Disposition", content_disposition(filename))]
+        )
 
 
 class MyAccountController(PaymentFormController):
@@ -18,6 +128,16 @@ class MyAccountController(PaymentFormController):
     @route("/my/home", type="http", auth="user", website=True)
     def account(self, redirect=None, **post):
         return request.render("website_compassion.my_account_layout", {})
+
+    @route("/my/download/<source>", type="http", auth="user", website=True)
+    def download_file(self, source, obj_id=None, child_id=None, **kw):
+        if source == "picture":
+            if child_id and obj_id:
+                return _download_image("single", obj_id, child_id)
+            elif child_id:
+                return _download_image("multiple", obj_id, child_id)
+            else:
+                return _download_image("all", obj_id, child_id)
 
     @route("/my/children", type="http", auth="user", website=True)
     def my_children(self, **kwargs):
@@ -35,17 +155,13 @@ class MyAccountController(PaymentFormController):
 
     @route("/my/child/<int:child_id>", type="http", auth="user", website=True)
     def my_child(self, child_id, **kwargs):
-        partner = request.env.user.partner_id
-        children = (partner.contracts_fully_managed +
-                    partner.contracts_correspondant +
-                    partner.contracts_paid) \
-            .mapped("child_id").sorted("preferred_name")
-        child_id = children.filtered(lambda child: child.id == child_id)
-        if not child_id:
+        children = _get_user_children()
+        child = children.filtered(lambda c: c.id == child_id)
+        if not child:
             return request.redirect(f"/my/children")
         else:
-            child_id.get_infos()
+            child.get_infos()
             return request.render(
                 "website_compassion.my_children_page_template",
-                {"child_id": child_id},
+                {"child_id": child},
             )

--- a/website_compassion/template/my_account_my_children.xml
+++ b/website_compassion/template/my_account_my_children.xml
@@ -18,6 +18,8 @@
                 <t t-call="website_compassion.my_children_navbar"/>
 
                 <t t-call="website_compassion.my_children_info"/>
+
+                <t t-call="website_compassion.my_children_pictures"/>
             </t>
             <script type="text/javascript" src="/website_compassion/static/src/js/my_children.js"/>
         </template>
@@ -232,6 +234,44 @@
                     <label><t t-esc="value"/></label>
                 </div>
             </div>
+        </template>
+
+        <!-- Children pictures inside the view -->
+        <template id="my_children_pictures">
+            <div class="container">
+                <h3><t t-esc="child_id.preferred_name"/>'<t t-esc="'' if child_id.preferred_name[-1] == 's' else 's'"/> pictures</h3>
+                <nav class="navbar navbar-expand-md">
+                    <ul class="nav nav-tabs">
+                        <t t-foreach="child_id.pictures_ids.sorted('date', reverse=True)" t-as="picture">
+                            <li class="m-2">
+                                <div class="card d-flex text-center border-0" style="width: 12rem; height: auto;">
+                                    <img class="mx-auto" t-att-src="picture.image_url" style="max-width: 120px; width: 100%; height: auto;"/>
+                                    <div class="card-body">
+                                        <t t-esc="picture.date.strftime('%e %B %Y')"/>
+                                        <br/>
+                                        <a t-attf-href="/my/download/picture?obj_id={{picture.id}}&amp;child_id={{child_id.id}}">Download</a>
+                                    </div>
+                                </div>
+                            </li>
+                        </t>
+                    </ul>
+                </nav>
+                <div class="alert alert-info alert-dismissable text-center" style="display: none;">
+                    This may take a few minutes... Please wait
+                </div>
+                <a t-attf-href="/my/download/picture?child_id={{child_id.id}}">Download all <t t-esc="child_id.preferred_name"/>'<t t-esc="'' if child_id.preferred_name[-1] == 's' else 's'"/> pictures</a>
+                <a t-attf-href="/my/download/picture" onclick="display_alert()" style="float: right;">Download all children's pictures</a>
+            </div>
+            <script>
+                let display_alert = function(){
+                    $(".alert").show("slow");
+                    setTimeout(
+                        function() {
+                            $(".alert").hide("slow");
+                        }, 7000
+                    );
+                };
+            </script>
         </template>
     </data>
 </odoo>

--- a/website_compassion/template/my_account_my_children.xml
+++ b/website_compassion/template/my_account_my_children.xml
@@ -74,151 +74,154 @@
         <template id="my_children_info">
             <div class="container">
                 <div class="row mt-4">
-                    <!-- General information -->
                     <div class="col-md-6">
-                        <h3>General information</h3>
-                        <!-- Age -->
-                        <t t-set="key" t-value="'Age'"/>
-                        <t t-set="value" t-value="child_id.age"/>
-                        <t t-call="website_compassion.fill_key_value"/>
+                        <!-- General information -->
+                        <t t-if="child_id.age or child_id.birthdate or child_id.gender or child_id.hobby_ids">
+                            <h3>General information</h3>
+                            <!-- Age -->
+                            <t t-set="key" t-value="'Age'"/>
+                            <t t-set="value" t-value="child_id.age"/>
+                            <t t-call="website_compassion.fill_key_value"/>
 
-                        <!-- Birthdate -->
-                        <t t-set="key" t-value="'Birthdate'"/>
-                        <t t-set="value" t-value="child_id.get_date('birthdate', 'date_full')"/>
-                        <t t-call="website_compassion.fill_key_value"/>
+                            <!-- Birthdate -->
+                            <t t-set="key" t-value="'Birthdate'"/>
+                            <t t-set="value" t-value="child_id.get_date('birthdate', 'date_full')"/>
+                            <t t-call="website_compassion.fill_key_value"/>
 
-                        <!-- Gender -->
-                        <t t-set="key" t-value="'Gender'"/>
-                        <t t-set="value" t-value="child_id.translate('gender')"/>
-                        <t t-call="website_compassion.fill_key_value"/>
+                            <!-- Gender -->
+                            <t t-set="key" t-value="'Gender'"/>
+                            <t t-set="value" t-value="child_id.translate('gender')"/>
+                            <t t-call="website_compassion.fill_key_value"/>
 
-                        <!-- Hobbies -->
-                        <t t-set="key" t-value="'Hobbies'"/>
-                        <t t-set="value" t-value="child_id.get_list('hobby_ids.value').capitalize()"/>
-                        <t t-call="website_compassion.fill_key_value"/>
+                            <!-- Hobbies -->
+                            <t t-set="key" t-value="'Hobbies'"/>
+                            <t t-set="value" t-value="child_id.get_list('hobby_ids.value').capitalize()"/>
+                            <t t-call="website_compassion.fill_key_value"/>
+
+                            <br/>
+                        </t>
+
+                        <!-- Education information -->
+                        <t t-if="child_id.education_level or child_id.academic_performance">
+                            <h3>Education</h3>
+                            <!-- Education level -->
+                            <t t-set="key" t-value="'Education level'"/>
+                            <t t-set="value" t-value="child_id.education_level"/>
+                            <t t-call="website_compassion.fill_key_value"/>
+
+                            <!-- Academic performance -->
+                            <t t-set="key" t-value="'Academic performance'"/>
+                            <t t-set="value" t-value="child_id.academic_performance"/>
+                            <t t-call="website_compassion.fill_key_value"/>
+
+                            <br/>
+                        </t>
+
+                        <!-- My community information -->
+                        <t t-if="child_id.project_id.closest_city or child_id.project_id.country_id.name or child_id.project_id.community_population or child_id.project_id.primary_language_id.name or child_id.project_id.primary_adults_occupation_ids or child_id.project_id.primary_diet_ids">
+                            <h3>My community</h3>
+                            <!-- Location (city, country), one or both may be empty, so we handle properly -->
+                            <t t-set="key" t-value="'Location'"/>
+                            <t t-set="value" t-value="', '.join(list(filter(None, [child_id.project_id.closest_city, child_id.project_id.country_id.name])))"/>
+                            <t t-call="website_compassion.fill_key_value"/>
+
+                            <!-- Population -->
+                            <t t-set="key" t-value="'Population'"/>
+                            <t t-set="value" t-value="child_id.project_id.community_population"/>
+                            <t t-call="website_compassion.fill_key_value"/>
+
+                            <!-- Language -->
+                            <t t-set="key" t-value="'Language'"/>
+                            <t t-set="value" t-value="child_id.project_id.primary_language_id.name"/>
+                            <t t-call="website_compassion.fill_key_value"/>
+
+                            <!-- Common job -->
+                            <t t-set="key" t-value="'Common jobs'"/>
+                            <t t-set="value" t-value="child_id.get_list('project_id.primary_adults_occupation_ids.value').capitalize()"/>
+                            <t t-call="website_compassion.fill_key_value"/>
+
+                            <!-- Typical food -->
+                            <t t-set="key" t-value="'Typical food'"/>
+                            <t t-set="value" t-value="child_id.get_list('project_id.primary_diet_ids.value').capitalize()"/>
+                            <t t-call="website_compassion.fill_key_value"/>
+
+                            <br/>
+                        </t>
                     </div>
 
-                    <!-- Family information -->
                     <div class="col-md-6">
-                        <h3>Family information</h3>
-                        <!-- Legal representatives, not a single string so we have to construct it -->
-                        <div class="row">
-                            <div class="col-6 border-right">
-                                <label><t t-esc="'Legal representatives'"/></label><br/>
-                            </div>
-                            <div class="col-6">
-                                <t t-if="child_id.household_id.member_ids">
+                        <!-- Family information -->
+                        <t t-if="child_id.household_id.member_ids or child_id.household_id.male_guardian_job or child_id.household_id.female_guardian_job or child_id.duty_ids">
+                            <h3>Family information</h3>
+                            <!-- Legal representatives, not a single string so we have to construct it -->
+                            <div class="row" t-if="child_id.household_id.member_ids">
+                                <div class="col-6 border-right">
+                                    <label><t t-esc="'Legal representatives'"/></label><br/>
+                                </div>
+                                <div class="col-6">
                                     <t t-foreach="child_id.household_id.member_ids" t-as="member">
                                         <t t-if="member.is_primary_caregiver">
                                             <label><t t-esc="member.role"/></label><br/>
                                         </t>
                                     </t>
-                                </t>
-                                <t t-else="">
-                                    <label>-</label><br/>
-                                </t>
+                                </div>
                             </div>
-                        </div>
 
-                        <!-- Family, not a single string so we have to construct it -->
-                        <div class="row">
-                            <div class="col-6 border-right">
-                                <label><t t-esc="'Family'"/></label><br/>
-                            </div>
-                            <div class="col-6">
-                                <t t-if="child_id.household_id.member_ids">
+                            <!-- Family, not a single string so we have to construct it -->
+                            <div class="row" t-if="child_id.household_id.member_ids">
+                                <div class="col-6 border-right">
+                                    <label><t t-esc="'Family'"/></label><br/>
+                                </div>
+                                <div class="col-6">
                                     <t t-foreach="child_id.household_id.member_ids" t-as="member">
                                         <t t-if="'Beneficiary' not in member.role">
                                             <label><t t-esc="member.name + ', ' + member.role"/></label><br/>
                                         </t>
                                     </t>
-                                </t>
-                                <t t-else="">
-                                    <label>-</label>
-                                </t>
+                                </div>
                             </div>
-                        </div>
 
-                        <!-- Father/representative's job -->
-                        <t t-set="key" t-value="'Father/representative\'s job'"/>
-                        <t t-set="value" t-value="child_id.household_id.male_guardian_job"/>
-                        <t t-call="website_compassion.fill_key_value"/>
+                            <!-- Father/representative's job -->
+                            <t t-set="key" t-value="'Father/representative\'s job'"/>
+                            <t t-set="value" t-value="child_id.household_id.male_guardian_job"/>
+                            <t t-call="website_compassion.fill_key_value"/>
 
-                        <!-- Mother/representative's job -->
-                        <t t-set="key" t-value="'Mother/representative\'s job'"/>
-                        <t t-set="value" t-value="child_id.household_id.female_guardian_job"/>
-                        <t t-call="website_compassion.fill_key_value"/>
+                            <!-- Mother/representative's job -->
+                            <t t-set="key" t-value="'Mother/representative\'s job'"/>
+                            <t t-set="value" t-value="child_id.household_id.female_guardian_job"/>
+                            <t t-call="website_compassion.fill_key_value"/>
 
-                        <!-- Household duties -->
-                        <t t-set="key" t-value="'Household duties'"/>
-                        <t t-set="value" t-value="child_id.get_list('duty_ids.value').capitalize()"/>
-                        <t t-call="website_compassion.fill_key_value"/>
-                    </div>
-                </div>
+                            <!-- Household duties -->
+                            <t t-set="key" t-value="'Household duties'"/>
+                            <t t-set="value" t-value="child_id.get_list('duty_ids.value').capitalize()"/>
+                            <t t-call="website_compassion.fill_key_value"/>
 
-                <div class="row mt-4">
-                    <!-- Education information -->
-                    <div class="col-md-6">
-                        <h3>Education</h3>
-                        <!-- Education level -->
-                        <t t-set="key" t-value="'Education level'"/>
-                        <t t-set="value" t-value="child_id.education_level"/>
-                        <t t-call="website_compassion.fill_key_value"/>
+                            <br/>
+                        </t>
 
-                        <!-- Academic performance -->
-                        <t t-set="key" t-value="'Academic performance'"/>
-                        <t t-set="value" t-value="child_id.academic_performance"/>
-                        <t t-call="website_compassion.fill_key_value"/>
-                    </div>
+                        <!-- Compassion center information -->
+                        <t t-set="child_activities" t-as="child_id.project_id.get_activity_for_age(child_id.age)"/>
+                        <t t-if="child_id.project_id.local_church_name or child_id.project_id.sponsorships_count or child_activities">
+                            <h3>Compassion center</h3>
+                            <!-- Project name -->
+                            <t t-set="key" t-value="'Project name'"/>
+                            <t t-set="value" t-value="child_id.project_id.local_church_name"/>
+                            <t t-call="website_compassion.fill_key_value"/>
 
-                    <!-- Compassion center information -->
-                    <div class="col-md-6">
-                        <h3>Compassion center</h3>
-                        <!-- Project name -->
-                        <t t-set="key" t-value="'Project name'"/>
-                        <t t-set="value" t-value="child_id.project_id.local_church_name"/>
-                        <t t-call="website_compassion.fill_key_value"/>
+                            <!-- Number of sponsor children -->
+                            <t t-set="key" t-value="'Number of sponsored children'"/>
+                            <t t-set="value" t-value="child_id.project_id.sponsorships_count"/>
+                            <t t-call="website_compassion.fill_key_value"/>
 
-                        <!-- Number of sponsor children -->
-                        <t t-set="key" t-value="'Number of sponsored children'"/>
-                        <t t-set="value" t-value="child_id.project_id.sponsorships_count"/>
-                        <t t-call="website_compassion.fill_key_value"/>
+                            <!-- Project activities -->
+                            <t t-if="child_activities">
+                                <t t-set="key" t-value="'Project activities'"/>
+                                <t t-set="value" t-value="', '.join(child_activities.mapped('value')).capitalize()"/>
+                                <t t-call="website_compassion.fill_key_value"/>
+                            </t>
 
-                        <!-- Project activities -->
-                        <t t-set="key" t-value="'Project activities'"/>
-                        <t t-set="value" t-value="', '.join(child_id.project_id.get_activity_for_age(child_id.age).mapped('value')).capitalize()"/>
-                        <t t-call="website_compassion.fill_key_value"/>
-                    </div>
-                </div>
-
-                <div class="row mt-4">
-                    <!-- My community information -->
-                    <div class="col-md-6">
-                        <h3>My community</h3>
-                        <!-- Location (city, country), one or both may be empty, so we handle properly -->
-                        <t t-set="key" t-value="'Location'"/>
-                        <t t-set="value" t-value="', '.join(list(filter(None, [child_id.project_id.closest_city, child_id.project_id.country_id.name])))"/>
-                        <t t-call="website_compassion.fill_key_value"/>
-
-                        <!-- Population -->
-                        <t t-set="key" t-value="'Population'"/>
-                        <t t-set="value" t-value="child_id.project_id.community_population"/>
-                        <t t-call="website_compassion.fill_key_value"/>
-
-                        <!-- Language -->
-                        <t t-set="key" t-value="'Language'"/>
-                        <t t-set="value" t-value="child_id.project_id.primary_language_id.name"/>
-                        <t t-call="website_compassion.fill_key_value"/>
-
-                        <!-- Common job -->
-                        <t t-set="key" t-value="'Common jobs'"/>
-                        <t t-set="value" t-value="child_id.get_list('project_id.primary_adults_occupation_ids.value').capitalize()"/>
-                        <t t-call="website_compassion.fill_key_value"/>
-
-                        <!-- Typical food -->
-                        <t t-set="key" t-value="'Typical food'"/>
-                        <t t-set="value" t-value="child_id.get_list('project_id.primary_diet_ids.value').capitalize()"/>
-                        <t t-call="website_compassion.fill_key_value"/>
+                            <br/>
+                        </t>
                     </div>
                 </div>
             </div>
@@ -238,7 +241,7 @@
 
         <!-- Children pictures inside the view -->
         <template id="my_children_pictures">
-            <div class="container">
+            <div class="container" t-if="child_id.pictures_ids">
                 <h3><t t-esc="child_id.preferred_name"/>'<t t-esc="'' if child_id.preferred_name[-1] == 's' else 's'"/> pictures</h3>
                 <nav class="navbar navbar-expand-md">
                     <ul class="nav nav-tabs">
@@ -261,17 +264,17 @@
                 </div>
                 <a t-attf-href="/my/download/picture?child_id={{child_id.id}}">Download all <t t-esc="child_id.preferred_name"/>'<t t-esc="'' if child_id.preferred_name[-1] == 's' else 's'"/> pictures</a>
                 <a t-attf-href="/my/download/picture" onclick="display_alert()" style="float: right;">Download all children's pictures</a>
+                <script>
+                    let display_alert = function(){
+                        $(".alert").show("slow");
+                        setTimeout(
+                            function() {
+                                $(".alert").hide("slow");
+                            }, 7000
+                        );
+                    };
+                </script>
             </div>
-            <script>
-                let display_alert = function(){
-                    $(".alert").show("slow");
-                    setTimeout(
-                        function() {
-                            $(".alert").hide("slow");
-                        }, 7000
-                    );
-                };
-            </script>
         </template>
     </data>
 </odoo>


### PR DESCRIPTION
The pictures of the children are now displayed inside the view and it is possible to download them in three different ways:
- only one single image of a child
- all the images of a given child
- all the images of all our children
If there are more than one image, then a _.zip_ archive is created with all the images inside.

Most of the modifications are already done in PR #1244, which is ready.