### PR TITLE
CO-3457 - fix wizard checker partner duplicate

### DIFF
--- a/partner_compassion/views/partner_check_double.xml
+++ b/partner_compassion/views/partner_check_double.xml
@@ -7,7 +7,9 @@
             <form>
                 <field name="mergeable_partner_ids"/>
                 <label for="selected_merge_partner_id"/>
-                <field name="selected_merge_partner_id" domain="[('id', 'in', mergeable_partner_ids[0][2])]" options="{'no_create': True}"/>
+                <field name="selected_merge_partner_id"
+                       domain="[('id', 'in', mergeable_partner_ids or False)]"
+                       options="{'no_create': True}"/>
                 <footer>
                     <button type='object' name='merge_with' string="Merge" attrs="{'invisible': [('selected_merge_partner_id', '=', False)]}" class="oe_highlight"/>
                     <button type='object' name='keep' string="Keep partners" />


### PR DESCRIPTION
- since odoo version 11, it is no longer necessary to specify [0] [2] in the xml file of the wizard view: https://github.com/odoo/odoo/commit/f14aab1827bb3c8ad7090a0c0f259a57e5ca6204