### PR TITLE
CO-3484 Gift history integration

### DIFF
--- a/website_compassion/__manifest__.py
+++ b/website_compassion/__manifest__.py
@@ -35,6 +35,7 @@
     "license": "AGPL-3",
     "website": "http://www.compassion.ch",
     "data": [
+        "security/ir.model.access.csv",
         "template/my_account_components.xml",
         "template/my_account_personal_info.xml",
         "template/my_account_payments.xml",

--- a/website_compassion/controllers/my_account.py
+++ b/website_compassion/controllers/my_account.py
@@ -155,13 +155,22 @@ class MyAccountController(PaymentFormController):
 
     @route("/my/child/<int:child_id>", type="http", auth="user", website=True)
     def my_child(self, child_id, **kwargs):
+        partner = request.env.user.partner_id
         children = _get_user_children()
-        child = children.filtered(lambda c: c.id == child_id)
+        child = children.filtered(lambda child: child.id == child_id)
+        lines = request.env["account.invoice.line"].search([
+            ("partner_id", "=", partner.id),
+            ("state", "=", "paid"),
+            ("contract_id.child_id", "=", child_id.id),
+            ("product_id.categ_id.id", "=", 5),
+            ("price_total", "!=", 0),
+        ])
         if not child:
             return request.redirect(f"/my/children")
         else:
             child.get_infos()
             return request.render(
                 "website_compassion.my_children_page_template",
-                {"child_id": child},
+                {"child_id": child,
+                 "line_ids": lines},
             )

--- a/website_compassion/controllers/my_account.py
+++ b/website_compassion/controllers/my_account.py
@@ -141,11 +141,7 @@ class MyAccountController(PaymentFormController):
 
     @route("/my/children", type="http", auth="user", website=True)
     def my_children(self, **kwargs):
-        partner = request.env.user.partner_id
-        children = (partner.contracts_fully_managed +
-                    partner.contracts_correspondant +
-                    partner.contracts_paid)\
-            .mapped("child_id").sorted("preferred_name")
+        children = _get_user_children()
         if len(children) == 0:
             return request.render(
                 "website_compassion.my_children_empty_page_content", {}
@@ -161,7 +157,7 @@ class MyAccountController(PaymentFormController):
         lines = request.env["account.invoice.line"].search([
             ("partner_id", "=", partner.id),
             ("state", "=", "paid"),
-            ("contract_id.child_id", "=", child_id.id),
+            ("contract_id.child_id", "=", child.id),
             ("product_id.categ_id.id", "=", 5),
             ("price_total", "!=", 0),
         ])

--- a/website_compassion/models/invoice_line.py
+++ b/website_compassion/models/invoice_line.py
@@ -6,5 +6,9 @@
 #    The licence is in the file __manifest__.py
 #
 ##############################################################################
-from . import compassion_project
-from . import invoice_line
+from odoo import models
+
+
+class AccountInvoiceLine(models.Model):
+    _name = "account.invoice.line"
+    _inherit = ["account.invoice.line", "translatable.model"]

--- a/website_compassion/security/ir.model.access.csv
+++ b/website_compassion/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+read_access_product_portal,Read access product portal,partner_compassion.model_product_product,base.group_portal,1,0,0,0
+read_access_category_portal,Read access category portal,product.model_product_category,base.group_portal,1,0,0,0

--- a/website_compassion/template/my_account_my_children.xml
+++ b/website_compassion/template/my_account_my_children.xml
@@ -20,6 +20,8 @@
                 <t t-call="website_compassion.my_children_info"/>
 
                 <t t-call="website_compassion.my_children_pictures"/>
+
+                <t t-call="website_compassion.my_children_gift_history"/>
             </t>
             <script type="text/javascript" src="/website_compassion/static/src/js/my_children.js"/>
         </template>
@@ -274,6 +276,37 @@
                         );
                     };
                 </script>
+            </div>
+        </template>
+
+        <template id="my_children_gift_history">
+            <div class="container" t-if="line_ids">
+                <h3>Gift history</h3>
+                <div class="row">
+                    <div class="col-4">
+                        <label><b>Fund</b></label>
+                    </div>
+                    <div class="col-4">
+                        <label><b>Date</b></label>
+                    </div>
+                    <div class="col-4">
+                        <label><b>Amount</b></label>
+                    </div>
+                </div>
+                <t t-foreach="line_ids" t-as="line">
+                    <div class="row">
+                        <div class="col-4">
+                            <label><t t-esc="line.product_id.name"/></label>
+                        </div>
+                        <div class="col-4">
+                            <label><t t-esc="line.get_date('create_date', 'date_full')"/></label>
+                        </div>
+                        <div class="col-4">
+                            <label><t t-esc="line.price_total"/></label>
+                        </div>
+                    </div>
+                </t>
+                <a href="https://compassion.ch/donations/" target="_blank">Make a donation</a>
             </div>
         </template>
     </data>


### PR DESCRIPTION
The gift history is now displayed in the view _My Children_. A link to the donations of the website as also been added.

The `id` of the category (Sponsorship gifts) has been hard coded, because the name is translated and hence was cumbersome to use.

For this to work, the portal group must be granted access to the model `product.product` as well as `product.category`.