### PR TITLE
Small bug fix for image resizing

### DIFF
--- a/crowdfunding_compassion/forms/project_creation_form.py
+++ b/crowdfunding_compassion/forms/project_creation_form.py
@@ -87,7 +87,7 @@ class ProjectCreationWizard(models.AbstractModel):
         def resize(image):
             width, height = image.size
             min_width, min_height = min(width, 900), min(height, 400)
-            factor = max(min_width / width, min_height / height)
+            factor = min(min_width / width, min_height / height)
             return image.resize((int(width * factor), int(height * factor)))
 
         def compress(image):


### PR DESCRIPTION
We wanted to force images uploaded to the crowdfunding website to be equal or smaller than 900 by 400 pixels images. This was done by computing the factor to bring the width or height to the desired length if it were any longer. Nevertheless, it was the bigger factor that was selected instead of the smaller one, thus allowing images greater than the desired size in one direction.

This is now fixed by selecting the smallest factor of the two instead.