### PR TITLE
CO-3537 Miscellaneous improvements and refactoring

### DIFF
--- a/website_compassion/controllers/my_account.py
+++ b/website_compassion/controllers/my_account.py
@@ -125,13 +125,9 @@ def _download_image(type, child_id=None, obj_id=None):
 
 
 class MyAccountController(PaymentFormController):
-    @route("/my", type="http", auth="user", website=True)
-    def home(self, **kw):
-        return request.redirect("/my/home")
-
-    @route("/my/home", type="http", auth="user", website=True)
+    @route(["/my", "/my/home"], type="http", auth="user", website=True)
     def account(self, redirect=None, **post):
-        return request.render("website_compassion.my_account_layout", {})
+        return request.redirect("/my/information")
 
     @route("/my/letter", type="http", auth="user", website=True)
     def my_letter(self, child_id=None, template_id=None, **kwargs):
@@ -156,8 +152,8 @@ class MyAccountController(PaymentFormController):
                 "website_compassion.letter_page_template",
                 {"child_id": child,
                  "template_id": template,
-                 "child_ids": children,
-                 "template_ids": templates},
+                 "children": children,
+                 "templates": templates},
             )
         else:
             return request.redirect(f"/my/letter?child_id={children[0].id}")
@@ -180,7 +176,9 @@ class MyAccountController(PaymentFormController):
                 ("partner_id", "=", partner.id),
                 ("child_id", "=", int(child_id)),
             ])
-            gift_categ = request.env.ref("sponsorship_compassion.product_category_gift")
+            gift_categ = request.env.ref(
+                "sponsorship_compassion.product_category_gift"
+            )
             lines = request.env["account.invoice.line"].sudo().search([
                 ("partner_id", "=", partner.id),
                 ("state", "=", "paid"),
@@ -188,13 +186,12 @@ class MyAccountController(PaymentFormController):
                 ("product_id.categ_id", "=", gift_categ.id),
                 ("price_total", "!=", 0),
             ])
-            child.get_infos()
             return request.render(
                 "website_compassion.my_children_page_template",
                 {"child_id": child,
-                 "child_ids": children,
-                 "letter_ids": letters,
-                 "line_ids": lines}
+                 "children": children,
+                 "letters": letters,
+                 "lines": lines}
             )
         else:
             return request.redirect(f"/my/children?child_id={children[0].id}")

--- a/website_compassion/static/src/js/my_account.js
+++ b/website_compassion/static/src/js/my_account.js
@@ -7,10 +7,9 @@ let displayAlert = function(id) {
     );
 };
 
-scrollToSelectedElements = async function() {
+window.onload = function() {
     const selected_elems = document.querySelectorAll("img[class~='border']");
-    // TODO: Find solution to remove next line
-    await new Promise(r => setTimeout(r, 2000));
+
     for (var i = 0 ; i < selected_elems.length ; ++i) {
         const elem = selected_elems[i];
         const card = document.getElementById(`card_${elem.id}`);
@@ -21,5 +20,3 @@ scrollToSelectedElements = async function() {
         });
     }
 }
-
-scrollToSelectedElements();

--- a/website_compassion/static/src/js/write_a_letter.js
+++ b/website_compassion/static/src/js/write_a_letter.js
@@ -243,6 +243,13 @@ const sendLetter = function(message_from) {
     xhr.onreadystatechange = function () {
         if (xhr.readyState === 4 && xhr.status === 200) {
             startStopLoading("sending");
+            // Empty images and text (to avoid duplicate)
+            document.getElementById("letter_content").value = ""
+            for (var i = 0 ; i < images_list.length ; i++) {
+                var image = images_list[i];
+                removeImage(image.name, image.size, image.type);
+            }
+
             displayAlert("letter_sent_correctly");
         }
     };

--- a/website_compassion/template/my_account_my_children.xml
+++ b/website_compassion/template/my_account_my_children.xml
@@ -13,7 +13,11 @@
 
                 <t t-call="website_compassion.my_children_gift_history"/>
 
+                <h2>First version for letters (icons to be determined, could also be color)</h2>
                 <t t-call="website_compassion.my_children_letters"/>
+
+                <h2>Second version for letters (download link position to be determined)</h2>
+                <t t-call="website_compassion.my_children_letters_v2"/>
             </t>
             <script type="text/javascript" src="/website_compassion/static/src/js/my_account.js"/>
         </template>
@@ -24,7 +28,7 @@
                 <div id="my_children_div" class="container" style="overflow-x:auto">
                     <ul class="nav nav-tabs d-flex flex-nowrap">
                         <!-- Finding children of the corresponding sponsor -->
-                        <t t-foreach="child_ids" t-as="child">
+                        <t t-foreach="children" t-as="child">
                             <!-- Setting headshot for each child -->
                             <t t-if="child.image_url">
                                 <t t-set="child_image" t-value="request.env[
@@ -260,8 +264,39 @@
             </div>
         </template>
 
+        <template id="my_children_gift_history">
+            <div class="container" t-if="lines">
+                <h3>Gift history</h3>
+                <div class="row">
+                    <div class="col-4">
+                        <label><b>Fund</b></label>
+                    </div>
+                    <div class="col-4">
+                        <label><b>Date</b></label>
+                    </div>
+                    <div class="col-4">
+                        <label><b>Amount</b></label>
+                    </div>
+                </div>
+                <t t-foreach="lines" t-as="line">
+                    <div class="row">
+                        <div class="col-4">
+                            <label><t t-esc="line.product_id.name"/></label>
+                        </div>
+                        <div class="col-4">
+                            <label><t t-esc="line.get_date('create_date', 'date_full')"/></label>
+                        </div>
+                        <div class="col-4">
+                            <label><t t-esc="line.price_total"/></label>
+                        </div>
+                    </div>
+                </t>
+                <a t-attf-href="https://compassion.ch/donations?{{request.env.user.partner_id.wordpress_form_data}}" target="_blank">Make a donation</a>
+            </div>
+        </template>
+
         <template id="my_children_letters">
-            <div class="container" t-if="letter_ids">
+            <div class="container" t-if="letters">
                 <h3>Letters</h3>
                 <div class="row">
                     <div class="col-3">
@@ -272,12 +307,14 @@
                     </div>
                 </div>
                 <div class="row">
-                    <t t-foreach="letter_ids" t-as="letter">
+                    <t t-foreach="letters" t-as="letter">
                         <div class="col-3">
                             <t t-if="letter.direction == 'Supporter To Beneficiary'">
+                                <span class="fa fa-arrow-right"/>
                                 <label>Me</label>
                             </t>
                             <t t-else="">
+                                <span class="fa fa-arrow-left"/>
                                 <label><t t-esc="child_id.preferred_name"/></label>
                             </t>
                         </div>
@@ -305,34 +342,47 @@
             </div>
         </template>
 
-        <template id="my_children_gift_history">
-            <div class="container" t-if="line_ids">
-                <h3>Gift history</h3>
+        <template id="my_children_letters_v2">
+            <t t-set="title" t-value="'My letters'"/>
+            <t t-set="letters_to_display" t-value="letters.filtered(lambda l: l.direction == 'Supporter To Beneficiary')"/>
+            <t t-call="website_compassion.display_letters"/>
+
+            <t t-set="title" t-value="child_id.preferred_name + ('\'' if child_id.preferred_name[-1] == 's' else '\'s') + ' letters'"/>
+            <t t-set="letters_to_display" t-value="letters.filtered(lambda l: l.direction == 'Beneficiary To Supporter')"/>
+            <t t-call="website_compassion.display_letters"/>
+        </template>
+
+        <template id="display_letters">
+            <div class="container" t-if="letters">
+                <h3><t t-esc="title"/></h3>
                 <div class="row">
-                    <div class="col-4">
-                        <label><b>Fund</b></label>
-                    </div>
                     <div class="col-4">
                         <label><b>Date</b></label>
                     </div>
-                    <div class="col-4">
-                        <label><b>Amount</b></label>
-                    </div>
                 </div>
-                <t t-foreach="line_ids" t-as="line">
-                    <div class="row">
+                <div class="row">
+                    <t t-foreach="letters_to_display" t-as="letter">
                         <div class="col-4">
-                            <label><t t-esc="line.product_id.name"/></label>
+                            <label><t t-esc="letter.get_date('scanned_date', 'date_full')"/></label>
                         </div>
                         <div class="col-4">
-                            <label><t t-esc="line.get_date('create_date', 'date_full')"/></label>
+                            <label><a t-attf-href="/b2s_image?id={{letter.uuid}}&amp;disp=inline&amp;type=pdf" target="_blank">View letter</a></label>
                         </div>
                         <div class="col-4">
-                            <label><t t-esc="line.price_total"/></label>
+                            <label><a t-attf-href="/b2s_image?id={{letter.uuid}}">Download letter</a></label>
                         </div>
-                    </div>
-                </t>
-                <a t-attf-href="https://compassion.ch/donations?{{request.env.user.partner_id.wordpress_form_data}}" target="_blank">Make a donation</a>
+                    </t>
+                </div>
+                <hr/>
+                <div id="download_my_children_letters" class="alert alert-info alert-dismissable text-center" style="display: none;">
+                    This may take a few minutes... Please wait
+                </div>
+                <a t-attf-href="/b2s_image/child?child_id={{child_id.id}}">
+                    Download all <t t-esc="child_id.preferred_name"/>'<t t-esc="'' if child_id.preferred_name[-1] == 's' else 's'"/> correspondence
+                </a>
+                <a t-attf-href="/b2s_image/child" onclick="displayAlert('download_my_children_letters')" style="float: right;">
+                    Download all children's correspondence
+                </a>
             </div>
         </template>
     </data>

--- a/website_compassion/template/my_account_my_children.xml
+++ b/website_compassion/template/my_account_my_children.xml
@@ -13,11 +13,14 @@
 
                 <t t-call="website_compassion.my_children_gift_history"/>
 
-                <h2>First version for letters (icons to be determined, could also be color)</h2>
+                <h2>First version for letters (icons to be determined more properly)</h2>
                 <t t-call="website_compassion.my_children_letters"/>
 
-                <h2>Second version for letters (download link position to be determined)</h2>
+                <h2>Second version for letters (colors to be determined more properly)</h2>
                 <t t-call="website_compassion.my_children_letters_v2"/>
+
+                <h2>Third version for letters (download link position to be determined)</h2>
+                <t t-call="website_compassion.my_children_letters_v3"/>
             </t>
             <script type="text/javascript" src="/website_compassion/static/src/js/my_account.js"/>
         </template>
@@ -343,6 +346,51 @@
         </template>
 
         <template id="my_children_letters_v2">
+            <div class="container" t-if="letters">
+                <h3>Letters</h3>
+                <div class="row">
+                    <div class="col-3">
+                        <label><b>From</b></label>
+                    </div>
+                    <div class="col-3">
+                        <label><b>Date</b></label>
+                    </div>
+                </div>
+                <t t-foreach="letters" t-as="letter">
+                    <div class="row" t-attf-style="background: {{'lightgray' if letter.direction == 'Supporter To Beneficiary' else 'white'}}">
+                        <div class="col-3">
+                            <t t-if="letter.direction == 'Supporter To Beneficiary'">
+                                <label>Me</label>
+                            </t>
+                            <t t-else="">
+                                <label><t t-esc="child_id.preferred_name"/></label>
+                            </t>
+                        </div>
+                        <div class="col-3">
+                            <label><t t-esc="letter.get_date('scanned_date', 'date_full')"/></label>
+                        </div>
+                        <div class="col-3">
+                            <label><a t-attf-href="/b2s_image?id={{letter.uuid}}&amp;disp=inline&amp;type=pdf" target="_blank">View letter</a></label>
+                        </div>
+                        <div class="col-3">
+                            <label><a t-attf-href="/b2s_image?id={{letter.uuid}}">Download letter</a></label>
+                        </div>
+                    </div>
+                </t>
+                <hr/>
+                <div id="download_my_children_letters" class="alert alert-info alert-dismissable text-center" style="display: none;">
+                    This may take a few minutes... Please wait
+                </div>
+                <a t-attf-href="/b2s_image/child?child_id={{child_id.id}}">
+                    Download all <t t-esc="child_id.preferred_name"/>'<t t-esc="'' if child_id.preferred_name[-1] == 's' else 's'"/> correspondence
+                </a>
+                <a t-attf-href="/b2s_image/child" onclick="displayAlert('download_my_children_letters')" style="float: right;">
+                    Download all children's correspondence
+                </a>
+            </div>
+        </template>
+
+        <template id="my_children_letters_v3">
             <t t-set="title" t-value="'My letters'"/>
             <t t-set="letters_to_display" t-value="letters.filtered(lambda l: l.direction == 'Supporter To Beneficiary')"/>
             <t t-call="website_compassion.display_letters"/>
@@ -353,7 +401,7 @@
         </template>
 
         <template id="display_letters">
-            <div class="container" t-if="letters">
+            <div class="container" t-if="letters_to_display">
                 <h3><t t-esc="title"/></h3>
                 <div class="row">
                     <div class="col-4">

--- a/website_compassion/template/my_account_write_a_letter.xml
+++ b/website_compassion/template/my_account_write_a_letter.xml
@@ -31,7 +31,7 @@
                 <div id="my_children_div" class="container" style="overflow-x:auto">
                     <ul class="nav nav-tabs d-flex flex-nowrap">
                         <!-- Finding children of the corresponding sponsor -->
-                        <t t-foreach="child_ids" t-as="child">
+                        <t t-foreach="children" t-as="child">
                             <!-- Setting headshot for each child -->
                             <t t-if="child.image_url">
                                 <t t-set="child_image" t-value="request.env[
@@ -69,9 +69,8 @@
         </template>
 
         <template id="letter_templates">
-
             <ul class="templates nav nav-tabs" style="height: 33rem; overflow-y: scroll">
-                <t t-foreach="template_ids" t-as="template">
+                <t t-foreach="templates" t-as="template">
                     <div class="w-50 p-2">
                         <div t-attf-id="card_template_{{template.id}}" t-attf-onclick="selectElement('{{template.id}}', 'template')" class="card card-clickable text-center">
                             <li>
@@ -82,7 +81,6 @@
                                     <img t-attf-id="template_{{template.id}}" t-att-name="template.name" class="template-image" t-att-src="template.template_image_url" alt="Template image" style="width: 95%; height: auto;"/>
                                 </t>
                                 <span t-attf-id="template_name_{{template.id}}" t-att-value="template.name" style="display: none;"/>
-                                <t t-esc="template.name"/>
                             </li>
                         </div>
                     </div>
@@ -95,7 +93,7 @@
             <button class="btn btn-primary w-100 mb-2" onclick="document.getElementById('file_selector').click();">
                 Add images
             </button>
-            <!-- TODO CO-765: Use this warning when no image was added to list -->
+            <!-- TODO CI-765: Use this warning when no image was added to list -->
             <div id="letter_images_duplicated" class="alert alert-info alert-dismissable text-center ml-2 mt-2 mb-2" style="display: none;">
                 The images that are selected multiple times are ignored
             </div>


### PR DESCRIPTION
According to feedback I got from the IT team and some things that I found, here are miscellaneous improvements for the different features that have been developed so far. Most of the modifications are straightforward. However, one or two points will be shortly covered here.

The color _primary_ that is wrong in the website should be directly set through the _GUI_. It can be done easily by going on _Customize -> Customize Theme_ and from there selecting the right primary color. There is one primary color per theme, so one should be careful to set the one of the default Compassion theme.

For the page _My children_ that is slow to load, for the moment a call to the function `get_info()` that is pretty slow has been removed. Still, we need to determine whether something additional can be done (not requiring a huge amount of work) and if the function should be called (but in background, to prevent slowing down the page loading).

I was not able to find a convincing icon to tell whether it is a letter that we wrote or received. However, the marketing department asked whether the letters could be split in two different columns (one for the S2B and one for the B2S). Personally, I prefer having all the letters in a single column (I think it is better to have a clear timing history than a clear history of who wrote which letter). So I left the two versions (with a big title each time) so that the marketing department can choose which version is the best. Moreover, each version has a point that needs to be addressed, which is presented in the big title. All of this to say that the two `<h2>` titles will be gone, and one of the version dropped as well.
For this part, one additional possibility would be to have one column, but propose a filter to the users. This filter would allow them to see only their letters, those from the child they sponsor of all their communications.