### PR TITLE
CO-3523 Differentiation of active and terminated sponsorships

### DIFF
--- a/crowdfunding_compassion/templates/my_account_crowdfunding.xml
+++ b/crowdfunding_compassion/templates/my_account_crowdfunding.xml
@@ -4,7 +4,7 @@
         <template id="my_account_crowdfunding" name="My account Crowdfunding" inherit_id="website_compassion.my_account_layout">
             <xpath expr="//ul/li[4]" position="after">
                 <t t-if="request.session.get('uid') and request.env.user.partner_id.crowdfunding_project_count">
-                    <li class="nav-item">
+                    <li t-attf-class="nav-item#{' active' if selected == 'together' else ''}">
                         <a class="nav-link" href="/my/together">Together</a>
                     </li>
                 </t>

--- a/crowdfunding_compassion/templates/my_account_crowdfunding_page.xml
+++ b/crowdfunding_compassion/templates/my_account_crowdfunding_page.xml
@@ -1,6 +1,7 @@
 <odoo>
     <data>
         <template id="my_account_crowdfunding_view_template" name="My Account Together">
+            <t t-set="selected" t-value="'together'"/>
             <t t-call="website_compassion.my_account_layout">
                 <t t-set="title">My Account | TOGETHER - Compassion Switzerland Fundraising</t>
 

--- a/muskathlon/templates/muskathlon_my_home.xml
+++ b/muskathlon/templates/muskathlon_my_home.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
     <template id="custom_portal_my_home" name="Custom My Portal">
+        <t t-set="selected" t-value="'muskathlon'"/>
         <t t-call="website_compassion.my_account_layout">
             <!-- Page content -->
             <div id="muskathlon_my_home" class="container">

--- a/muskathlon/templates/my_account_muskathlon.xml
+++ b/muskathlon/templates/my_account_muskathlon.xml
@@ -4,7 +4,7 @@
         <template id="my_account_muskathlon" name="My Account Muskathlon" inherit_id="website_compassion.my_account_layout">
             <xpath expr="//ul/li[4]" position="after">
                 <t t-if="request.session.get('uid') and request.env.user.partner_id.is_muskathlon">
-                    <li class="nav-item">
+                    <li t-attf-class="nav-item#{' active' if selected == 'muskathlon' else ''}">
                         <a class="nav-link" href="/my/muskathlon">Muskathlon</a>
                     </li>
                 </t>

--- a/website_compassion/template/my_account_components.xml
+++ b/website_compassion/template/my_account_components.xml
@@ -12,16 +12,16 @@
                     <div class="container">
                         <div class="collapse navbar-collapse">
                             <ul class="nav navbar-nav mr-auto text-left">
-                                <li class="nav-item">
+                                <li t-attf-class="nav-item#{' active' if selected == 'child' else ''}">
                                     <a class="nav-link" href="/my/children">My children</a>
                                 </li>
-                                <li class="nav-item">
+                                <li t-attf-class="nav-item#{' active' if selected == 'info' else ''}">
                                     <a class="nav-link" href="/my/information">Personal information</a>
                                 </li>
-                                <li class="nav-item">
+                                <li t-attf-class="nav-item#{' active' if selected == 'donation' else ''}">
                                     <a class="nav-link" href="/my/donations">Donations / Invoicing</a>
                                 </li>
-                                <li class="nav-item">
+                                <li t-attf-class="nav-item#{' active' if selected == 'letter' else ''}">
                                     <a class="nav-link" href="/my/letter">Write a letter</a>
                                 </li>
                             </ul>

--- a/website_compassion/template/my_account_my_children.xml
+++ b/website_compassion/template/my_account_my_children.xml
@@ -4,7 +4,23 @@
         <!-- This templates creates the view "My Children". It receives the following arguments: -->
         <!--     1. child_id, the record of the child that is currently selected -->
         <template id="my_children_page_template" name="My Children">
+            <t t-set="selected" t-value="'child'"/>
             <t t-call="website_compassion.my_account_layout">
+                <t t-if="display_state">
+                    <nav class="navbar navbar-expand-md navbar-light bg-light">
+                        <div class="container">
+                            <ul class="nav navbar-nav mr-auto text-left">
+                                <li t-attf-class="nav-item#{' active' if state == 'active' else ''}">
+                                    <a class="nav-link" t-attf-href="/my/children?state=active&amp;child_id=#{child_id.id}">Active sponsorships</a>
+                                </li>
+                                <li t-attf-class="nav-item#{' active' if state == 'terminated' else ''}">
+                                    <a class="nav-link" t-attf-href="/my/children?state=terminated&amp;child_id=#{child_id.id}">Terminated sponsorships</a>
+                                </li>
+                            </ul>
+                        </div>
+                    </nav>
+                </t>
+
                 <t t-call="website_compassion.my_children_horizontal_pictures"/>
 
                 <body data-spy="scroll" data-target="#section_menu">
@@ -70,7 +86,7 @@
                             <!-- Creating the actual card for each children -->
                             <div t-attf-id="card_child_{{child.id}}" class="card card-clickable text-center bg-light m-1" style="width: 9rem;height: 10rem;">
                                 <li class="nav-item">
-                                    <a class="nav-link border-0" t-attf-href="/my/children?child_id={{child.id}}">
+                                    <a class="nav-link border-0" t-attf-href="/my/children?state={{state}}&amp;child_id={{child.id}}">
                                         <!-- We add a border for the selected child -->
                                         <t t-if="child.id == child_id.id">
                                             <img t-attf-id="child_{{child.id}}" class="rounded-circle border border-5 border-primary" t-att-src="child_image" alt="Child image" style="width: 90%; height: 90%;"/>

--- a/website_compassion/template/my_account_personal_info.xml
+++ b/website_compassion/template/my_account_personal_info.xml
@@ -2,6 +2,7 @@
 <odoo>
     <data>
         <template id="my_information_page_template" name="Personal information">
+            <t t-set="selected" t-value="'info'"/>
             <t t-call="website_compassion.my_account_layout">
                 <div class="container">
                     <!-- Load modals for forms -->

--- a/website_compassion/template/my_account_write_a_letter.xml
+++ b/website_compassion/template/my_account_write_a_letter.xml
@@ -2,6 +2,7 @@
 <odoo>
     <data>
         <template id="letter_page_template" name="Write a letter">
+            <t t-set="selected" t-value="'letter'"/>
             <t t-call="website_compassion.my_account_layout">
                 <t t-call="website_compassion.letter_horizontal_pictures"/>
 


### PR DESCRIPTION
A new menu is available on the My Children screen and allows to differentiate _active_ from _terminated_ sponsorships. The menu is accessible only if there are children in both categories (if a sponsor only has _active_ or only _terminated_ sponsorships, it will not appear). The menu that is selected is now highlighted, in order to ease the comprehension of where the user is at any given time.