### PR TITLE
CO-3608, CO-3606: Double pictures and view letter correction.

### DIFF
--- a/website_compassion/controllers/my_account.py
+++ b/website_compassion/controllers/my_account.py
@@ -98,7 +98,8 @@ def _create_archive(images, archive_name):
             filename = path.basename(full_path)
 
             # Create file, write to archive and delete it from os
-            urlretrieve(img.image_url, filename)
+            img_url = f'https://erp.compassion.ch/web/image/compassion.child.pictures/{img.id}/fullshot/'
+            urlretrieve(img_url, filename)
             archive.write(filename, full_path)
             remove(filename)
 
@@ -457,8 +458,8 @@ class MyAccountController(PaymentFormController):
             return params[key]
 
         if source == "picture":
-            child_id = _get_required_param("child_id", kw)
-            obj_id = _get_required_param("obj_id", kw)
+            child_id = kw.get("child_id", False)
+            obj_id = kw.get("obj_id", False)
 
             if child_id and obj_id:
                 return _download_image("single", child_id, obj_id)

--- a/website_compassion/template/my_account_my_children.xml
+++ b/website_compassion/template/my_account_my_children.xml
@@ -267,7 +267,7 @@
                         <t t-foreach="child_id.pictures_ids.sorted('date', reverse=True)" t-as="picture">
                             <li class="m-2">
                                 <div class="card d-flex text-center border-0" style="width: 12rem; height: auto;">
-                                    <img class="mx-auto" t-att-src="picture.image_url" style="max-width: 120px; width: 100%; height: auto;"/>
+                                    <img class="mx-auto" t-attf-src='https://erp.compassion.ch/web/image/compassion.child.pictures/{{picture.id}}/fullshot/' style="max-width: 120px; width: 100%; height: auto;"/>
                                     <div class="card-body pt-2">
                                         <div t-esc="picture.get_date('date', 'MMMM Y').title()"/>
                                         <a class="btn btn-primary mt-2" t-attf-href="/my/download/picture?obj_id={{picture.id}}&amp;child_id={{child_id.id}}">Download</a>
@@ -365,7 +365,7 @@
                             <label><t t-esc="letter.get_date('scanned_date', 'date_full')"/></label>
                         </div>
                         <div class="col-3">
-                            <label><a class="btn btn-primary" t-attf-href="/b2s_image?id={{letter.uuid}}&amp;disp=inline&amp;type=pdf" target="_blank">View</a></label>
+                            <label><a class="btn btn-primary" t-attf-href="/b2s_image?id={{letter.uuid}}&amp;disposition=inline&amp;file_type=pdf" target="_blank">View</a></label>
                         </div>
                         <div class="col-3">
                             <label><a class="btn btn-primary" t-attf-href="/b2s_image?id={{letter.uuid}}">Download</a></label>


### PR DESCRIPTION
- Change the url link photo to prevent double
- Correct the parameter names when calling bs2_image.
- No get_required_param  when calling download/source