### PR TITLE
Fix segment survey layout issue

### DIFF
--- a/partner_compassion/templates/survey_templates.xml
+++ b/partner_compassion/templates/survey_templates.xml
@@ -16,16 +16,30 @@
             <!-- Change next and previous page order (more logical in interface)-->
             <xpath expr="//div[@class='text-center mt16 mb16']" position="replace">
                 <div class="text-center mt16 mb16">
-                    <button t-if="last" type="submit" class="btn btn-primary" name="button_submit" value="finish">Submit survey</button>
-                    <button t-if="not last" type="submit" class="btn btn-primary" name="button_submit" value="next">Next page</button>
-                    <button t-if="survey.users_can_go_back and page_nr > 0" type="submit" class="btn btn-secondary" name="button_submit" value="previous">Previous page</button>
+                    <button t-if="last" type="submit" class="btn btn-primary" name="button_submit" value="finish">Submit
+                        survey
+                    </button>
+                    <button t-if="not last" type="submit" class="btn btn-primary" name="button_submit" value="next">Next
+                        page
+                    </button>
+                    <button t-if="survey.users_can_go_back and page_nr > 0" type="submit" class="btn btn-secondary"
+                            name="button_submit" value="previous">Previous page
+                    </button>
                 </div>
             </xpath>
 
             <!-- Add margins in survey -->
             <xpath expr="div[@class='o_page_header']" position="attributes">
-                <attribute name="class">jumbotron mt-32 mb-32 o_page_header</attribute>
+                <attribute name="t-attf-class">jumbotron mt-32 mb-32 o_page_header #{'' if page.title else 'pb-4'}
+                </attribute>
             </xpath>
+
+            <xpath expr="//div[@class='js_errzone alert alert-danger']" position="attributes">
+                <attribute name="t-attf-class">
+                    js_errzone alert alert-danger mt-3 pb-0 pt-3
+                </attribute>
+            </xpath>
+
 
         </template>
 
@@ -36,7 +50,8 @@
             </xpath>
 
             <xpath expr="//div[@class='row']/div" position="attributes">
-                <attribute name="t-attf-class">col-#{'md' if question.left_label else 'lg-' + question.column_nb}</attribute>
+                <attribute name="t-attf-class">col-#{'md' if question.left_label else 'lg-' + question.column_nb}
+                </attribute>
             </xpath>
             <xpath expr="//div[@class='row']/div[1]" position="before">
                 <t t-if="question.left_label">
@@ -58,8 +73,10 @@
         <template id="custom_simple_choice" name="simple choice custom" inherit_id="survey.simple_choice">
 
             <xpath expr="//div[@t-as='label']" position="replace">
-                    <div t-foreach='question.labels_ids' t-as='label' t-attf-class="col-#{'md' if question.left_label else 'lg-' + question.column_nb}">
-                    <label t-att-class="' bg-success d-flex flex-column' if quizz_correction and label.quizz_mark > 0.0 else 'd-flex flex-column align-items-center'" style="height: 100%">
+                <div t-foreach='question.labels_ids' t-as='label'
+                     t-attf-class="col-#{'md' if question.left_label else 'lg-' + question.column_nb}">
+                    <label t-att-class="' bg-success d-flex flex-column' if quizz_correction and label.quizz_mark > 0.0 else 'd-flex flex-column align-items-center'"
+                           style="height: 100%">
                         <span t-field='label.value' class="text-center"/>
                         <input type="radio" t-att-name="prefix" t-att-value='label.id' class="w-100 mx-auto mt-auto"/>
                     </label>

--- a/partner_compassion/templates/survey_templates.xml
+++ b/partner_compassion/templates/survey_templates.xml
@@ -16,15 +16,9 @@
             <!-- Change next and previous page order (more logical in interface)-->
             <xpath expr="//div[@class='text-center mt16 mb16']" position="replace">
                 <div class="text-center mt16 mb16">
-                    <button t-if="last" type="submit" class="btn btn-primary" name="button_submit" value="finish">Submit
-                        survey
-                    </button>
-                    <button t-if="not last" type="submit" class="btn btn-primary" name="button_submit" value="next">Next
-                        page
-                    </button>
-                    <button t-if="survey.users_can_go_back and page_nr > 0" type="submit" class="btn btn-secondary"
-                            name="button_submit" value="previous">Previous page
-                    </button>
+                    <button t-if="last" type="submit" class="btn btn-primary" name="button_submit" value="finish">Submit survey</button>
+                    <button t-if="not last" type="submit" class="btn btn-primary" name="button_submit" value="next">Next page</button>
+                    <button t-if="survey.users_can_go_back and page_nr > 0" type="submit" class="btn btn-secondary" name="button_submit" value="previous">Previous page</button>
                 </div>
             </xpath>
 


### PR DESCRIPTION
- add padding on header when title is empty to avoid page number being crossed
- add padding on top of error message to match bottom margin of inner paragraph