### PR TITLE
CO-3623 override new mailchimp method to launch job on update

### DIFF
--- a/mass_mailing_switzerland/models/res_partner_category.py
+++ b/mass_mailing_switzerland/models/res_partner_category.py
@@ -16,6 +16,8 @@ class ResPartnerCategory(models.Model):
     @api.multi
     def update_partner_tags(self):
         # Update mailing contacts and mailchimp when tags are recomputed.
+        to_update = self.env["res.partner"]
+
         for tag in self:
             old_partners = set(tag.mapped("partner_ids").ids)
             tag.mapped("partner_ids.mailing_contact_ids").write({
@@ -26,8 +28,8 @@ class ResPartnerCategory(models.Model):
             tag.mapped("partner_ids.mailing_contact_ids").write({
                 "tag_ids": [(4, tag.id)]
             })
-            to_update = old_partners ^ new_partners
-            if to_update:
-                self.env["mail.mass_mailing.contact"].with_delay().update_all_merge_fields_job(list(to_update))
+            # xor operator. either no longer have this tag or just got it.
+            to_update |= self.env["res.partner"].search([("id", "in", list(old_partners ^ new_partners))])
 
+        to_update.process_mailchimp_update()
         return True


### PR DESCRIPTION
:warning: **Update mailchimp module with new modifications before merging this PR**

- override `process_mailchimp_update` to change partner update to mailchimp behavior
- launch already created job `update_all_merge_fields` for specified partners

This will ensure all update to mailchimp append in a separate thread (`with_delay`) thus avoiding issue on immediate update.

