### PR TITLE
CO-3621 correct no_money_extension decrement and tested

### DIFF
--- a/partner_communication_switzerland/models/compassion_hold.py
+++ b/partner_communication_switzerland/models/compassion_hold.py
@@ -156,8 +156,10 @@ class CompassionHold(models.Model):
                     sponsorship.state == "mandate" and sponsor.bank_ids
             ):
                 try:
+                    previous_extension = hold.no_money_extension
                     super(CompassionHold, hold).postpone_no_money_hold()
-                    hold.no_money_extension -= 1
+                    if previous_extension < hold.no_money_extension:
+                        hold.no_money_extension = previous_extension
                     continue
                 except:
                     failed += hold

--- a/partner_communication_switzerland/tests/__init__.py
+++ b/partner_communication_switzerland/tests/__init__.py
@@ -12,3 +12,4 @@ from . import test_bug_fixes
 from . import test_welcome_letters
 from . import test_sms_communication
 from . import test_sms_provider
+from . import test_hold_expiration

--- a/partner_communication_switzerland/tests/test_hold_expiration.py
+++ b/partner_communication_switzerland/tests/test_hold_expiration.py
@@ -1,0 +1,78 @@
+##############################################################################
+#
+#    Copyright (C) 2021 Compassion CH (http://www.compassion.ch)
+#    Releasing children from poverty in Jesus' name
+#    @author: Jonathan Guerne <guernej@compassion.ch>
+#
+#    The licence is in the file __manifest__.py
+#
+##############################################################################
+from odoo.addons.child_compassion.models.compassion_hold import HoldType
+from odoo.addons.sponsorship_compassion.tests.test_sponsorship_compassion import (
+    BaseSponsorshipTest,
+)
+
+import mock
+
+mock_update_hold = (
+    "odoo.addons.child_compassion.models.compassion_hold" ".CompassionHold.update_hold"
+)
+
+
+class TestHolds(BaseSponsorshipTest):
+    def setUp(self):
+        super().setUp()
+
+        child1 = self.create_child(self.ref(11))
+        sp_group = self.create_group({"partner_id": self.michel.id})
+        self.sponsorship1 = self.create_contract(
+            {
+                "partner_id": self.michel.id,
+                "group_id": sp_group.id,
+                "child_id": child1.id,
+            },
+            [{"amount": 50.0}],
+        )
+
+        child2 = self.create_child(self.ref(11))
+        sp_group2 = self.create_group({"partner_id": self.thomas.id})
+        self.sponsorship2 = self.create_contract(
+            {
+                "partner_id": self.thomas.id,
+                "group_id": sp_group2.id,
+                "child_id": child2.id,
+            },
+            [{"amount": 50.0}],
+        )
+
+    @mock.patch(mock_update_hold)
+    def test_hold_extension(self, update_hold):
+        """sending reminder should not impact the no_money_extension field
+        also hold should be extendable multiple times.
+        """
+        update_hold.return_value = True
+
+        self.sponsorship1.hold_id.write({
+            "child_id": self.sponsorship1.child_id.id,
+        })
+
+        self.sponsorship2.hold_id.write({
+            "type": HoldType.SUB_CHILD_HOLD.value,
+            "child_id": self.sponsorship2.child_id.id
+        })
+
+        for sponsorship in [self.sponsorship1, self.sponsorship2]:
+
+            self.assertEqual("draft", sponsorship.state)
+
+            self.assertEqual(0, sponsorship.hold_id.no_money_extension)
+
+            sponsorship.hold_id._send_hold_reminder(None)
+
+            self.assertEqual(0, sponsorship.hold_id.no_money_extension)
+
+            # assert hold can be extended multiple times
+            for _ in range(4):
+                previous_expiration = sponsorship.hold_id.expiration_date
+                sponsorship.hold_id._send_hold_reminder(None)
+                self.assertGreater(sponsorship.hold_id.expiration_date, previous_expiration)


### PR DESCRIPTION
- on `_send_hold_reminder()` no money extension is decremented if sponsorship is in "draft" state
  - change decrement to revert to old value if nedded (based on `postpone_no_money_hold` code)

- added testcase to assess good behavior for `no_money_hold` and `sub_child_hold`