### PR TITLE
CO-3571 compute number of sponsorship per churches

### DIFF
--- a/partner_compassion/__manifest__.py
+++ b/partner_compassion/__manifest__.py
@@ -29,7 +29,7 @@
 # pylint: disable=C8101
 {
     "name": "Upgrade Partners for Compassion Suisse",
-    "version": "12.0.1.1.2",
+    "version": "12.0.1.1.3",
     "category": "Partner",
     "author": "Compassion CH",
     "license": "AGPL-3",

--- a/partner_compassion/migrations/12.0.1.1.3/post-migration.py
+++ b/partner_compassion/migrations/12.0.1.1.3/post-migration.py
@@ -1,0 +1,10 @@
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, installed_version):
+    if not installed_version:
+        return
+
+    churches = env["res.partner"].search([("is_church", "=", True)])
+    churches.update_number_sponsorships()

--- a/partner_compassion/models/partner_compassion.py
+++ b/partner_compassion/models/partner_compassion.py
@@ -276,6 +276,9 @@ class ResPartner(models.Model):
         """
         Update the sponsorship number for the related church as well.
         """
+        church_to_update = self.filtered(lambda x: x.church_id and x.church_id != x).mapped("church_id")
+        if church_to_update:
+            church_to_update.update_number_sponsorships()
         return super().update_number_sponsorships()
 
     @api.depends("survey_inputs")
@@ -621,6 +624,14 @@ class ResPartner(models.Model):
     ##########################################################################
     #                             PRIVATE METHODS                            #
     ##########################################################################
+
+    @api.constrains("church_id")
+    def _check_church_id(self):
+        for record in self:
+            if record.is_church and record.church_id:
+                raise models.ValidationError(
+                    'Can not both be and have a church')
+
     @api.model
     def _address_fields(self):
         """ Returns the list of address fields that are synced from the parent


### PR DESCRIPTION
- change update_count_sponsorship method to update related churches count
- add check to avoid recursive call
- add constraint to ensure new partner could not both be church and have a church
- test
- make migration to update all church count of sponsorships