### PR TITLE
CO-3627 remplace samba by sftp on forget me action

### DIFF
--- a/partner_compassion/__manifest__.py
+++ b/partner_compassion/__manifest__.py
@@ -54,7 +54,7 @@
         "l10n_ch_zip",  # oca_addon/l10n_switzerland
         "web_view_google_map" # oca_addon/web_view_google_map
     ],
-    "external_dependencies": {"python": ["pandas", "pyminizip", "magic"]},
+    "external_dependencies": {"python": ["pandas", "pyminizip", "magic", "pysftp"]},
     "data": [
         "security/ir.model.access.csv",
         "security/criminal_record_groups.xml",


### PR DESCRIPTION
- remplace samba by sftp 
- ssh key for security
- tested on local environnement

A **non-empty** zip file must already exist on the NAS. Change `partner_compassion.store_path` parameter to refer it 