### PR TITLE
CO-3676 add onboarding_start_date and change onboarding base automations

### DIFF
--- a/partner_communication_switzerland/__manifest__.py
+++ b/partner_communication_switzerland/__manifest__.py
@@ -29,7 +29,7 @@
 # pylint: disable=C8101
 {
     "name": "Compassion CH Partner Communications",
-    "version": "12.0.1.1.1",
+    "version": "12.0.1.1.2",
     "category": "Other",
     "author": "Compassion CH",
     "license": "AGPL-3",

--- a/partner_communication_switzerland/data/onboarding_process.xml
+++ b/partner_communication_switzerland/data/onboarding_process.xml
@@ -253,8 +253,8 @@
             <field name="name">Sponsorship Onboarding: step1</field>
             <field name="model_id" ref="model_recurring_contract"/>
             <field name="trigger">on_time</field>
-            <field name="trg_date_id" ref="recurring_contract.field_recurring_contract__start_date"/>
-            <field name="filter_domain" eval="[('type', 'like', 'S'),('state', 'not in', ['cancelled','terminated','draft']),('origin_id.type', '!=', 'transfer'),('start_date', '&gt;=', datetime.today()),('parent_id','=',False),('correspondent_id.email', '!=', False),('correspondent_id.global_communication_delivery_preference', 'not in', ['physical','none'])]"/>
+            <field name="trg_date_id" ref="partner_communication_switzerland.field_recurring_contract__onboarding_start_date"/>
+            <field name="filter_domain" eval="[('type', 'like', 'S'),('state', 'not in', ['cancelled','terminated','draft']),('origin_id.type', '!=', 'transfer'),('start_date', '&gt;=', datetime.today()),('parent_id','=',False),('correspondent_id.email', '!=', False),('correspondent_id.global_communication_delivery_preference', 'not in', ['physical','none']),('onboarding_start_date', '!=', False)]"/>
             <field name="trg_date_range">5</field>
             <field name="trg_date_range_type">day</field>
             <field name="state">communication</field>
@@ -265,8 +265,8 @@
             <field name="name">Sponsorship Onboarding: step2</field>
             <field name="model_id" ref="model_recurring_contract"/>
             <field name="trigger">on_time</field>
-            <field name="trg_date_id" ref="recurring_contract.field_recurring_contract__start_date"/>
-            <field name="filter_domain" eval="[('type', 'like', 'S'),('state', 'not in', ['cancelled','terminated','draft']),('origin_id.type', '!=', 'transfer'),('start_date', '&gt;=', datetime.today()),('parent_id','=',False),('correspondent_id.email', '!=', False),('correspondent_id.global_communication_delivery_preference', 'not in', ['physical','none'])]"/>
+            <field name="trg_date_id" ref="partner_communication_switzerland.field_recurring_contract__onboarding_start_date"/>
+            <field name="filter_domain" eval="[('type', 'like', 'S'),('state', 'not in', ['cancelled','terminated','draft']),('origin_id.type', '!=', 'transfer'),('start_date', '&gt;=', datetime.today()),('parent_id','=',False),('correspondent_id.email', '!=', False),('correspondent_id.global_communication_delivery_preference', 'not in', ['physical','none']), ('onboarding_start_date', '!=', False)]"/>
             <field name="trg_date_range">8</field>
             <field name="trg_date_range_type">day</field>
             <field name="state">communication</field>
@@ -277,8 +277,8 @@
             <field name="name">Sponsorship Onboarding: step3</field>
             <field name="model_id" ref="model_recurring_contract"/>
             <field name="trigger">on_time</field>
-            <field name="trg_date_id" ref="recurring_contract.field_recurring_contract__start_date"/>
-            <field name="filter_domain" eval="[('type', 'like', 'S'),('state', 'not in', ['cancelled','terminated','draft']),('origin_id.type', '!=', 'transfer'),('is_first_sponsorship', '=', True),('start_date', '&gt;=', datetime.today()),('correspondent_id.email', '!=', False),('correspondent_id.global_communication_delivery_preference', 'not in', ['physical','none'])]"/>
+            <field name="trg_date_id" ref="partner_communication_switzerland.field_recurring_contract__onboarding_start_date"/>
+            <field name="filter_domain" eval="[('type', 'like', 'S'),('state', 'not in', ['cancelled','terminated','draft']),('origin_id.type', '!=', 'transfer'),('is_first_sponsorship', '=', True),('start_date', '&gt;=', datetime.today()),('correspondent_id.email', '!=', False),('correspondent_id.global_communication_delivery_preference', 'not in', ['physical','none']), ('onboarding_start_date', '!=', False)]"/>
             <field name="trg_date_range">12</field>
             <field name="trg_date_range_type">day</field>
             <field name="state">communication</field>
@@ -289,8 +289,8 @@
             <field name="name">Sponsorship Onboarding: step4</field>
             <field name="model_id" ref="model_recurring_contract"/>
             <field name="trigger">on_time</field>
-            <field name="trg_date_id" ref="recurring_contract.field_recurring_contract__start_date"/>
-            <field name="filter_domain" eval="[('type', 'like', 'S'),('state', 'not in', ['cancelled','terminated','draft']),('origin_id.type', '!=', 'transfer'),('is_first_sponsorship', '=', True),('start_date', '&gt;=', datetime.today()),('correspondent_id.email', '!=', False),('correspondent_id.global_communication_delivery_preference', 'not in', ['physical','none'])]"/>
+            <field name="trg_date_id" ref="partner_communication_switzerland.field_recurring_contract__onboarding_start_date"/>
+            <field name="filter_domain" eval="[('type', 'like', 'S'),('state', 'not in', ['cancelled','terminated','draft']),('origin_id.type', '!=', 'transfer'),('is_first_sponsorship', '=', True),('start_date', '&gt;=', datetime.today()),('correspondent_id.email', '!=', False),('correspondent_id.global_communication_delivery_preference', 'not in', ['physical','none']), ('onboarding_start_date', '!=', False)]"/>
             <field name="trg_date_range">15</field>
             <field name="trg_date_range_type">day</field>
             <field name="state">communication</field>
@@ -301,8 +301,8 @@
             <field name="name">Sponsorship Onboarding: step5</field>
             <field name="model_id" ref="model_recurring_contract"/>
             <field name="trigger">on_time</field>
-            <field name="trg_date_id" ref="recurring_contract.field_recurring_contract__start_date"/>
-            <field name="filter_domain" eval="[('type', 'like', 'S'),('state', 'not in', ['cancelled','terminated','draft']),('origin_id.type', '!=', 'transfer'),('is_first_sponsorship', '=', True),('start_date', '&gt;=', datetime.today()),('correspondent_id.email', '!=', False),('correspondent_id.global_communication_delivery_preference', 'not in', ['physical','none'])]"/>
+            <field name="trg_date_id" ref="partner_communication_switzerland.field_recurring_contract__onboarding_start_date"/>
+            <field name="filter_domain" eval="[('type', 'like', 'S'),('state', 'not in', ['cancelled','terminated','draft']),('origin_id.type', '!=', 'transfer'),('is_first_sponsorship', '=', True),('start_date', '&gt;=', datetime.today()),('correspondent_id.email', '!=', False),('correspondent_id.global_communication_delivery_preference', 'not in', ['physical','none']), ('onboarding_start_date', '!=', False)]"/>
             <field name="trg_date_range">18</field>
             <field name="trg_date_range_type">day</field>
             <field name="state">communication</field>

--- a/partner_communication_switzerland/migrations/12.0.1.1.2/post-migration.py
+++ b/partner_communication_switzerland/migrations/12.0.1.1.2/post-migration.py
@@ -1,0 +1,10 @@
+from openupgradelib import openupgrade
+
+
+def migrate(cr, installed_version):
+    if not installed_version:
+        return
+
+    # Update data
+    openupgrade.load_xml(
+        cr, "partner_communication_switzerland", "data/onboarding_process.xml")

--- a/partner_communication_switzerland/models/contracts.py
+++ b/partner_communication_switzerland/models/contracts.py
@@ -52,6 +52,10 @@ class RecurringContract(models.Model):
     origin_name = fields.Char(related="origin_id.name")
     is_first_sponsorship = fields.Boolean(readonly=True)
 
+    onboarding_start_date = fields.Date(help="Indicates when the first email of "
+                                             "the onboarding process was sent.",
+                                        copy=False)
+
     @api.onchange("origin_id")
     def _do_not_send_letter_to_transfer(self):
         if self.origin_id.type == "transfer" or self.origin_id.name == "Reinstatement":

--- a/partner_communication_switzerland/models/partner_communication.py
+++ b/partner_communication_switzerland/models/partner_communication.py
@@ -451,6 +451,7 @@ class PartnerCommunication(models.Model):
         - Update donor tag
         - Sends SMS for sms send_mode
         - Add to zoom session when zoom invitation is sent
+        - Set onboarding_start_date when first communication is sent
         :return: True
         """
         sms_jobs = self.filtered(lambda j: j.send_mode == "sms")
@@ -548,6 +549,18 @@ class PartnerCommunication(models.Model):
                 lang=invitation.partner_id.lang).get_next_session()
             if next_zoom:
                 next_zoom.add_participant(invitation.partner_id)
+
+        welcome_onboarding = self.env.ref(
+            "partner_communication_switzerland.config_onboarding_sponsorship_confirmation"
+        )
+
+        contracts_ids = other_jobs.filtered(
+            lambda j: j.config_id == welcome_onboarding and
+            j.get_objects().filtered("is_first_sponsorship")).mapped(lambda x: x.get_objects())
+
+        contracts_ids.write({
+            "onboarding_start_date": datetime.now()
+        })
 
         return True
 

--- a/partner_communication_switzerland/models/partner_communication.py
+++ b/partner_communication_switzerland/models/partner_communication.py
@@ -559,7 +559,7 @@ class PartnerCommunication(models.Model):
             j.get_objects().filtered("is_first_sponsorship")).mapped(lambda x: x.get_objects())
 
         contracts_ids.write({
-            "onboarding_start_date": datetime.now()
+            "onboarding_start_date": datetime.today()
         })
 
         return True

--- a/partner_communication_switzerland/tests/__init__.py
+++ b/partner_communication_switzerland/tests/__init__.py
@@ -13,3 +13,4 @@ from . import test_sms_communication
 from . import test_sms_provider
 from . import test_hold_expiration
 from . import test_lifecycle_events
+from . import test_onboarding

--- a/partner_communication_switzerland/tests/test_onboarding.py
+++ b/partner_communication_switzerland/tests/test_onboarding.py
@@ -1,0 +1,64 @@
+##############################################################################
+#
+#    Copyright (C) 2021 Compassion CH (http://www.compassion.ch)
+#    Releasing children from poverty in Jesus' name
+#    @author: Jonathan Guerne <guernej@compassion.ch>
+#
+#    The licence is in the file __manifest__.py
+#
+##############################################################################
+import mock
+from odoo.addons.sponsorship_compassion.tests.test_sponsorship_compassion import (
+    BaseSponsorshipTest,
+)
+
+mock_update_hold = (
+    "odoo.addons.child_compassion.models.compassion_hold" ".CompassionHold.update_hold"
+)
+
+
+class TestOnBoarding(BaseSponsorshipTest):
+
+
+    def setUp(self):
+        super().setUp()
+        self.michel.ref = self.ref(7)
+
+        payment_mode_lsv = self.env.ref("sponsorship_switzerland.payment_mode_lsv")
+        self.sp_group = self.create_group(
+            {"partner_id": self.michel.id, "payment_mode_id": payment_mode_lsv.id, }
+        )
+
+    @mock.patch(mock_update_hold)
+    def test_correct_onboarding_start_date(self, hold_mock):
+        """onboarding_start_date should be set once the welcome communication is sent"""
+
+        hold_mock.return_value = True
+
+        child = self.create_child(self.ref(11))
+        partner = self.michel
+
+        sponsorship = self.create_contract(
+            {
+                "partner_id": partner.id,
+                "group_id": self.sp_group.id,
+                "child_id": child.id,
+            },
+            [{"amount": 50.0}],
+        )
+
+        sponsorship.contract_waiting()
+
+        welcome_ref = self.env.ref("partner_communication_switzerland.config_onboarding_sponsorship_confirmation")
+
+        welcome_job = self.env["partner.communication.job"].search([
+            ("config_id", "=", welcome_ref.id),
+            ("partner_id", "=", sponsorship.correspondent_id.id)
+        ])
+
+        self.assertIsNot(welcome_job, False)
+        self.assertFalse(sponsorship.onboarding_start_date)
+
+        welcome_job.send()
+
+        self.assertIsNot(sponsorship.onboarding_start_date, False)

--- a/partner_communication_switzerland/views/contract_view.xml
+++ b/partner_communication_switzerland/views/contract_view.xml
@@ -16,6 +16,9 @@
                 <!-- this field is there because the type of origin_id couldn't be reached with the xml file -->
                 <field name="send_introduction_letter" attrs="{'invisible': [('origin_type','!=','transfer'),('origin_name','!=','Reinstatement')]}"/>
             </xpath>
+            <xpath expr="//field[@name='activation_date']" position="after">
+                <field name="onboarding_start_date" />
+            </xpath>
         </field>
      </record>
 </odoo>


### PR DESCRIPTION
- onboarding_start_date is set when first communication (welcome and payment information) is sent
    - date is displayed on contract form view
    - test correct behavior
- onboarding_start_date is used in onboarding_process base automation
    - use post_migration to update xml data 