### PR TITLE
CO-3688 a specific logic on mail delivery failure for letter and onboarding

### DIFF
--- a/partner_communication_switzerland/models/mail_tracking_event.py
+++ b/partner_communication_switzerland/models/mail_tracking_event.py
@@ -142,7 +142,7 @@ class MailTrackingEvent(models.Model):
         if partner_id:
             self.env["partner.communication.job"].create(
                 {
-                    "config_id": invalid_comm,
+                    "config_id": invalid_comm.id,
                     "partner_id": partner_id,
                     "object_ids": partner_id,
                 }


### PR DESCRIPTION
:warning: for now those communication were sent either 2 or 3 days after the initial communication if it wasn't open. This logic is still in place and could, in some case, cause some duplicate communication 