### PR TITLE
CO-3696 communication are correctly sent to partner or correspondent

### DIFF
--- a/partner_communication_switzerland/models/contracts.py
+++ b/partner_communication_switzerland/models/contracts.py
@@ -672,4 +672,4 @@ class RecurringContract(models.Model):
                 ]
             )
             if not already_sent:
-                self.with_context({}).send_communication(config, partner)
+                self.with_context({}).send_communication(config, correspondent)


### PR DESCRIPTION
change call of `send_communication` method to use the boolean field correspondent available in the `_send_new_dossier` method. 

This prevent to address partner's communication to correspondent