### PR TITLE
CO-3706 change the way the image is loaded in report

### DIFF
--- a/partner_communication_switzerland/models/partner_communication.py
+++ b/partner_communication_switzerland/models/partner_communication.py
@@ -438,7 +438,7 @@ class PartnerCommunication(models.Model):
             "doc_ids": children.ids,
         }
         pdf = self._get_pdf_from_data(
-            data, self.env.ref("report_compassion.report_childpack_small")
+            data, self.sudo().env.ref("report_compassion.report_childpack_small")
         )
         return {_("child dossier.pdf"): [report_name, pdf]}
 

--- a/report_compassion/__manifest__.py
+++ b/report_compassion/__manifest__.py
@@ -29,7 +29,7 @@
 # pylint: disable=C8101
 {
     "name": "Compassion CH PDF-Qweb Reports",
-    "version": "12.0.1.0.3",
+    "version": "12.0.1.0.4",
     "category": "Other",
     "author": "Compassion CH",
     "license": "AGPL-3",

--- a/report_compassion/migrations/12.0.1.0.4/post-migration.py
+++ b/report_compassion/migrations/12.0.1.0.4/post-migration.py
@@ -1,0 +1,9 @@
+from openupgradelib import openupgrade
+
+
+def migrate(cr, version):
+    if not version:
+        return
+
+    # Force loading new BVR reports
+    openupgrade.load_xml(cr, "report_compassion", "report/childpack.xml")

--- a/report_compassion/report/childpack.xml
+++ b/report_compassion/report/childpack.xml
@@ -246,7 +246,7 @@
                         </div>
                     </div>
                     <div class="photo">
-                        <span t-field="o.fullshot" t-options='{"widget": "image"}'/>
+                        <img t-if="o.fullshot" t-attf-src="data:image/jpg;base64,{{ o.fullshot }}"/>
                         <p t-field="o.local_id" id="child-ref"/>
                     </div>
                     <div class="summary">


### PR DESCRIPTION
because this report was generated via an automated action when it used Wkhtmltopdf to get the fullshot image from odoo api it failed with an error access issue. 

Wkhtmltopdf use to current request.session to query the api, when generating reports via a based automation the system user is not logged so the session is empty. The meant that the request would be handle via a public user which caused the access issue.

The solution proposed here is to create the image in advance. Instead of sending a link to the image we place the whole image in the html field. The access to the resource can then simply be granted via a sudo() command 