### PR TITLE
CO-3829 : number of sponsorship on Mailchimp is wrong if many partner…

### DIFF
--- a/mass_mailing_switzerland/models/mass_mailing_contact.py
+++ b/mass_mailing_switzerland/models/mass_mailing_contact.py
@@ -69,7 +69,7 @@ class MassMailingContact(models.Model):
     sponsored_child_your_child = fields.Char(compute="_compute_sponsored_child_fields")
     pending_letter_child_names = fields.Char(compute="_compute_sponsored_child_fields")
 
-    numspons = fields.Integer(compute="_compute_sponsored_child_fields")
+    numspons = fields.Char(compute="_compute_sponsored_child_fields")
 
     _sql_constraints = [(
         "unique_email", "unique(email)", "This mailing contact already exists"


### PR DESCRIPTION
… linked

- add numspon in mass_mailing_contact which is the amount of sponsored
children for a email address (this new merge field should be added or changed on the production server)
- use the partner with the most children sponsored as the mailing recipient
