### PR TITLE
CO-3824 : adding the new note from the statement to the invoice created

### DIFF
--- a/sponsorship_switzerland/models/completion_rules.py
+++ b/sponsorship_switzerland/models/completion_rules.py
@@ -350,7 +350,7 @@ class StatementCompletionRule(models.Model):
 
     def _generate_invoice_line(self, invoice_id, product, st_line, partner_id):
         inv_line_data = {
-            "name": product.name,
+            "name": st_line.get("note") or product.name,
             "account_id": product.property_account_income_id.id,
             "price_unit": st_line["amount"],
             "price_subtotal": st_line["amount"],


### PR DESCRIPTION
If the note is present in the bank statement change the name of the invoice line to this note