### PR TITLE
CO-3835 : Make "Write a letter" page available without login

### DIFF
--- a/website_compassion/controllers/my_account.py
+++ b/website_compassion/controllers/my_account.py
@@ -234,7 +234,7 @@ class MyAccountController(PaymentFormController):
         # reset password
         crypt_context = CryptContext(schemes=["pbkdf2_sha512", "plaintext"], deprecated=["plaintext"])
         password_encrypted = crypt_context.encrypt(password)
-        request.env.cr.execute(f"UPDATE res_users SET password='{password_encrypted}' WHERE login='{login}';")
+        request.env.cr.execute("UPDATE res_users SET password=%s WHERE login=%s;", [password_encrypted, login])
         request.env.cr.commit()
 
         # authenticate

--- a/website_compassion/controllers/my_account.py
+++ b/website_compassion/controllers/my_account.py
@@ -211,23 +211,32 @@ class MyAccountController(PaymentFormController):
         partner = res_partner.search([["uuid", "=", partner_uuid]], limit=1)
         partner = partner.sudo()
 
-        if len(partner) <= 0:
-            # account does not exist
-            return request.redirect(f"/my/{redirect_page}")
+        redirect_page_request = request.redirect(f"/my/{redirect_page}")
 
-        if res_users.search([["partner_id", "=", partner.id]], limit=1):
-            # already have an account
-            return request.redirect(f"/my/{redirect_page}")
+        if not partner:
+            # partner does not exist
+            return redirect_page_request
 
-        login = "magic_login_" + secrets.token_urlsafe(16)
-        values = {
-            "login": partner.email or login,
-            "partner_id": partner.id,
-        }
+        user = res_users.search([["partner_id", "=", partner.id]], limit=1)
 
-        partner.signup_prepare()
-        _, login, _ = res_users.signup(values=values, token=partner.signup_token)
+        if user and not user.created_with_magic_link:
+            # user already have an account not created with the magic link
+            # this will ask him to log in then redirect him on the route asked
+            return redirect_page_request
 
+        if not user:
+            # don't have a res_user must be created
+            login = MyAccountController._create_magic_user_from_partner(partner)
+        else:
+            # already have a res_user created with a magic link
+            login = user.login
+
+        MyAccountController._reset_password_and_authenticate(login)
+
+        return redirect_page_request
+
+    @staticmethod
+    def _reset_password_and_authenticate(login):
         # create a random password
         password = secrets.token_urlsafe(16)
 
@@ -239,9 +248,23 @@ class MyAccountController(PaymentFormController):
 
         # authenticate
         request.session.authenticate(request.session.db, login, password)
+        return True
 
-        return request.redirect(f"/my/{redirect_page}")
+    @staticmethod
+    def _create_magic_user_from_partner(partner):
+        res_users = request.env["res.users"].sudo()
 
+        values = {
+            # ensure a login when the partner doesnt have an email
+            "login": partner.email or "magic_login_" + secrets.token_urlsafe(16),
+            "partner_id": partner.id,
+            "created_with_magic_link": True,
+        }
+
+        # create a signup_token and create the account
+        partner.signup_prepare()
+        _, login, _ = res_users.signup(values=values, token=partner.signup_token)
+        return login
 
     @route(["/my", "/my/home", "/my/account"], type="http", auth="user", website=True)
     def account(self, redirect=None, **post):

--- a/website_compassion/models/res_user.py
+++ b/website_compassion/models/res_user.py
@@ -8,13 +8,16 @@
 ##############################################################################
 import logging
 
-from odoo import models, _
+from odoo import models, _, fields
+from odoo.odoo import api
 
 _logger = logging.getLogger(__name__)
 
 
 class ResUsers(models.Model):
     _inherit = 'res.users'
+
+    created_with_magic_link = fields.Boolean(default=False)
 
     def reset_password(self, login):
         """ retrieve the user corresponding to login (login or email),


### PR DESCRIPTION
Implement a magic route that create a user from a partner UUID and log it to my compassion

The magic route only work once (one time login) and only for partners without a My Compassion account.

If the user used this route and want to login again he must:
- Have access his mail and reset his My Compassion password with the reset password form
- Otherwise he must contact us to change his login from "magic_login_XXXX" to his actual mail address

Partner with a My Compassion account (even the one that used the route previously):
- Will be redirected to the login page

It would probably be possible to create a route that even work with partners that already have My Compassion account but it would require me more time to investigate on the authentications mechanism in Odoo.
Though I wouldn't recommend to create this route since it would probably create a security breach.