### PR TITLE
CO-3849: in Mycompassion, the invoice open for January 2022 are displ…

### DIFF
--- a/website_compassion/template/my_account_donations.xml
+++ b/website_compassion/template/my_account_donations.xml
@@ -218,8 +218,9 @@
                     <t t-set="children" t-value="invoice.invoice_line_ids.mapped('contract_id.child_id')"/>
                     <div class="row">
                         <div class="col-6">
-                            <label><t t-esc="invoice.get_date('date_invoice', 'MMMM Y').title()"/></label>
+                            <label><t t-esc="invoice.get_date('date_invoice', 'MMMM yyyy').title()"/></label>
                         </div>
+                        <div class="col-3">
                         <div class="col-3">
                             <label><t t-esc="children.get_list('preferred_name', 3, children.get_number())"/></label>
                         </div>
@@ -254,7 +255,7 @@
                             <label>
                                 <t t-if="invoice.invoice_category == 'sponsorship'">
                                     <span>Sponsorship </span>
-                                    <t t-esc="invoice.get_date('date_invoice', 'MMMM Y').title()"/> (<t t-esc="children.get_list('preferred_name', 2, children.get_number())"/>)
+                                    <t t-esc="invoice.get_date('date_invoice', 'MMMM yyyy').title()"/> (<t t-esc="children.get_list('preferred_name', 2, children.get_number())"/>)
                                 </t>
                                 <t t-else="">
                                     <t t-esc="invoice.invoice_line_ids.get_list('product_id.name')"/>
@@ -262,7 +263,7 @@
                             </label>
                         </div>
                         <div class="col-3">
-                            <label><t t-esc="invoice.get_date('last_payment', 'd MMM Y')"/></label>
+                            <label><t t-esc="invoice.get_date('last_payment', 'd MMM yyyy')"/></label>
                         </div>
                         <div class="col-3">
                             <label><t t-raw="int(invoice.amount_total)"/> <t t-esc="invoice.currency_id.name"/> </label>


### PR DESCRIPTION
…ayed january 2021

Somehow, the 1st of january 2022 is still in 2021 according to the iso calendar (which we were using, probably an american thing which mess up the time zones), see below. + babel does some weird things (it only uses the year as iso and not the rest) so its even more confusing that we dont obtain december 2021.

```
$ python -c "from datetime import datetime; print(datetime(2022, 1, 1).isocalendar())"
(2021, 52, 6)
```