### PR TITLE
CS-661 Support template for Christmas Gift Fund failed

### DIFF
--- a/partner_compassion/models/partner_bank_compassion.py
+++ b/partner_compassion/models/partner_bank_compassion.py
@@ -18,6 +18,23 @@ class ResPartnerBank(models.Model):
 
     _inherit = "res.partner.bank"
 
+    def build_swiss_code_vals(self, amount, *args):
+        """In l10n_ch's build_swiss_code_vals the amount must be a number
+        and can't be empty to be allowed in post offices.
+        This function is a workaround to this problem.
+        We also ensure that the amount is in the range specified by the swiss qr specifications.
+        """
+        must_be_corrected = type(amount) not in [int, float] or not (0.01 <= amount <= 999999999.99)
+        if not must_be_corrected:
+            return super().build_swiss_code_vals(amount, *args)
+
+        amount = -3141592.64 # dummy value
+        qr_code_vals = super().build_swiss_code_vals(amount, *args)
+        # ensure that this position is still the amount
+        assert qr_code_vals[18] == f"{amount:.2f}"
+        qr_code_vals[18] = ""
+        return qr_code_vals
+
     @api.model
     def create(self, data):
         """Override function to notify creation in a message


### PR DESCRIPTION
For qr payment slip implement workaround to handle invalid amount as custom amount instead (0 is considered invalid)