### PR TITLE
CO-3873 Next invoice dates are set at the date of creation instead of…

### DIFF
--- a/wordpress_connector/__manifest__.py
+++ b/wordpress_connector/__manifest__.py
@@ -29,7 +29,7 @@
 # pylint: disable=C8101
 {
     "name": "Compassion CH Wordpress Connector",
-    "version": "12.0.1.0.0",
+    "version": "12.0.1.0.1",
     "category": "Social",
     "author": "Emanuel Cino",
     "license": "AGPL-3",

--- a/wordpress_connector/migrations/12.0.1.0.1/post-migration.py
+++ b/wordpress_connector/migrations/12.0.1.0.1/post-migration.py
@@ -1,0 +1,23 @@
+from openupgradelib import openupgrade
+from dateutil.relativedelta import relativedelta
+
+
+@openupgrade.migrate(use_env=True)
+def migrate(env, version):
+    if not version:
+        return
+
+    # Associate already created toilets fund to new xml record
+    sponsorships = env["recurring.contract"].search(
+        [("create_uid.name", "=", "WordPress Imports")]
+    )
+
+    for s in sponsorships:
+        d = s.next_invoice_date
+        if not d:
+            continue
+        if d.day != 1 and d.day != 25:
+            month_delta = relativedelta(months=0 if d.day < 15 else 1)
+            next_invoice = d.replace(day=1) + month_delta
+            s.next_invoice_date = next_invoice
+

--- a/wordpress_connector/migrations/12.0.1.0.1/post-migration.py
+++ b/wordpress_connector/migrations/12.0.1.0.1/post-migration.py
@@ -8,14 +8,14 @@ def migrate(env, version):
         return
 
     # Associate already created toilets fund to new xml record
-    sponsorships = env["recurring.contract"].search(
-        [("create_uid.name", "=", "WordPress Imports")]
-    )
+    sponsorships = env["recurring.contract"].search([
+        ("create_uid.name", "=", "WordPress Imports"),
+        ("next_invoice_date", "!=", False),
+        ("state", "not in", ["cancelled", "terminated"])
+    ])
 
     for s in sponsorships:
         d = s.next_invoice_date
-        if not d:
-            continue
         if d.day != 1 and d.day != 25:
             month_delta = relativedelta(months=0 if d.day < 15 else 1)
             next_invoice = d.replace(day=1) + month_delta

--- a/wordpress_connector/models/contracts.py
+++ b/wordpress_connector/models/contracts.py
@@ -206,7 +206,6 @@ class Contracts(models.Model):
                 "child_id": child.id,
                 "type": sponsorship_type,
                 "contract_line_ids": lines,
-                "next_invoice_date": fields.Date.today(),
                 "source_id": utms["source"],
                 "medium_id": utms.get("medium", internet_id),
                 "campaign_id": utms["campaign"],


### PR DESCRIPTION
… the 1st of the month for wordpress sponsorships


- Remove the next_invoice_date (which was set to today) when creating the sponsorship from Wordpress (thus use the default one which is correct)
**NOT TESTED**

- Create a migration which fix this problem in the current db