### PR TITLE
CS-524 Limit size of picture uploads on Together

### DIFF
--- a/crowdfunding_compassion/controllers/homepage_controller.py
+++ b/crowdfunding_compassion/controllers/homepage_controller.py
@@ -11,7 +11,7 @@ from odoo.addons.website_compassion.tools.image_compression import compress_big_
 
 SPONSOR_HEADER = compress_big_images(base64.b64encode(file_open(
     "crowdfunding_compassion/static/src/img/sponsor_children_banner.jpg", "rb"
-).read()), max_bytes_size=2e4, max_width=400)
+).read()), max_width=400)
 
 SPONSOR_ICON = base64.b64encode(file_open(
     "crowdfunding_compassion/static/src/img/icn_children.png", "rb").read())
@@ -65,7 +65,6 @@ class HomepageController(Controller):
                 "header_image":
                     compress_big_images(
                         fund.image_large,
-                        max_bytes_size=2e4,
                         max_width=400
                     ) if fund.image_large else SPONSOR_HEADER,
 

--- a/crowdfunding_compassion/forms/project_creation_form.py
+++ b/crowdfunding_compassion/forms/project_creation_form.py
@@ -6,6 +6,7 @@
 #    The licence is in the file __manifest__.py
 #
 ##############################################################################
+import base64
 from datetime import datetime
 
 import logging
@@ -68,7 +69,6 @@ class ProjectCreationWizard(models.AbstractModel):
             step_values = self._prepare_step_values_to_store(self.request.form, {})
             self.wiz_save_step(step_values)
         return super().form_next_url(main_object) + "?save=True"
-
 
     def sanitized_url(values, key):
         def validate_url(url):

--- a/website_compassion/tools/image_compression.py
+++ b/website_compassion/tools/image_compression.py
@@ -2,42 +2,20 @@ import base64
 from io import BytesIO
 from PIL import Image
 
-def compress_big_images(b64_data, max_width=900, max_height=400, max_bytes_size=2e5):
-    """
-    Method that tries to compress an image receveived as parameter if this
-    image is too big (greater than 200KB). If the image is small enough or
-    if the compression does not improve the results, we simply return the
-    old version of the image.
 
-    :param max_bytes_size: The maximum allowed image size in byte
-    :param max_height: height resize threshold
-    :param max_width: width resize threshold
+def compress_big_images(b64_data, max_width=900, max_height=400):
+    """
+    Resize an image to fit into a specific box size
+
     :param b64_data: the data of the image to compress, expressed as a
     base64 string.
-    :return: either the original image, if it is small enough (<200KB)
-    or if the compression does not reduce size, or a new image that has
-    been compressed, again as a base64 string.
+    :param max_width: width of the box
+    :param max_height: height of the box
+
+    :return: the compressed image in b64
     """
-
-    def resize(image):
-        width, height = image.size
-        _width, _height = min(width, max_width), min(height, max_height)
-        factor = min(_width / width, _height / height)
-        return image.resize((int(width * factor), int(height * factor)))
-
-    def compress(image):
-        buffer = BytesIO()
-        image.convert("RGB").save(buffer, format='JPEG', optimize=True)
-        return base64.b64encode(buffer.getvalue())
-
-    old_image = b64_data
-    # If length in byte is greater than 200KB
-    bytes_len = 3 * (len(b64_data) / 4)
-    if bytes_len > max_bytes_size:
-        bytes_data = BytesIO(base64.b64decode(b64_data))
-        img = Image.open(bytes_data)
-        new_image = compress(resize(img))
-        new_bytes_len = 3 * (len(new_image) / 4)
-        # We don't change the image if there is no improvement
-        return new_image if bytes_len > new_bytes_len else old_image
-    return old_image
+    img = Image.open(BytesIO(base64.b64decode(b64_data)))
+    img.thumbnail((max_width, max_height), Image.LANCZOS)
+    buffer = BytesIO()
+    img.convert("RGB").save(buffer, format='JPEG', optimize=True)
+    return base64.b64encode(buffer.getvalue())


### PR DESCRIPTION
Images for projects on Together were already resized.
I've just changed the compression function to uses the pillow algorithm instead of an homemade one
I've also remove an feature in this function that was not really useful and understandable which was using the file size as an indicator instead of the bitmap size.