### PR TITLE
CS-677 Odoo- insert manually date of Child protection signature

### DIFF
--- a/partner_compassion/views/partner_compassion_view.xml
+++ b/partner_compassion/views/partner_compassion_view.xml
@@ -494,7 +494,7 @@
         <field name="arch" type="xml">
             <field name="privacy_statement_ids" position="after">
                 <group string="Child Protection Charter Agreement" name="child_protection_charter_fields">
-                    <field string="Has agreed" name="has_agreed_child_protection_charter" readonly="1"/>
+                    <field string="Has agreed" name="has_agreed_child_protection_charter"/>
                     <field string="Date agreed" name="date_agreed_child_protection_charter" readonly="1"/>
                 </group>
                 <group string="Other" name="other_fields">


### PR DESCRIPTION
Allow to change the has_agreed_child_protection_charter from the view form.
Now we can enable and disable this field, so a message is logged when it occurs and the date is updated