### PR TITLE
CO-3882 online payment comes with "10 jahre Aarau" analytic account b…

### DIFF
--- a/crowdfunding_compassion/models/account_invoice_line.py
+++ b/crowdfunding_compassion/models/account_invoice_line.py
@@ -23,7 +23,7 @@ class AccountInvoiceLine(models.Model):
         # The campaign takes precedence over analytic at creation
         # because the donation may come from a campaign and we need to preserve
         # this information
-        if "campaign_id" in vals:
+        if vals.get("campaign_id"):
             analytic = self.env["account.analytic.account"].search([
                 ("campaign_id", "=", vals["campaign_id"])
             ], limit=1)


### PR DESCRIPTION
…y default

When the invoice was created with an empty campaign_id, the analytic tag was set using the first one that does have a campaign_id
Which correspond to nearly every analytic tag, thus the first one was use (alphabetically).