### PR TITLE
CO-3880 print reminder for lsv/direct debit does not join the QR slip

### DIFF
--- a/report_compassion/report/bvr_sponsorship.xml
+++ b/report_compassion/report/bvr_sponsorship.xml
@@ -179,6 +179,10 @@
         <t t-set="contract_groups" t-value="sponsorships.mapped('group_id')"/>
         <t t-set="o" t-value="contract_groups[0]"/>
         <t t-set="reference" t-value="o.bvr_reference"/>
+        <!-- in some cases, the bvr_reference is no set, we recompute it in such cases -->
+        <t t-if="not reference or reference == ''">
+            <t t-set="reference" t-value="o.compute_partner_bvr_ref()"/>
+        </t>
         <t t-set="due"
            t-value="int(sum(sponsorships.mapped('due_invoice_ids').mapped('amount_total')) if 'active' in sponsorships.mapped('state') else sum(sponsorships.mapped('total_amount')) * min(sponsorships.mapped('group_id.advance_billing_months')))"/>
         <t t-set="communication">


### PR DESCRIPTION
re-evaluate the reference when it's not set to ensure the slip can be processed