### PR TITLE
CO-3920: link to make a gift online from my account are wrong

### DIFF
--- a/website_compassion/i18n/de.po
+++ b/website_compassion/i18n/de.po
@@ -204,6 +204,11 @@ msgid "<span>Make a donation</span>"
 msgstr "Ein Geschenk machen<br/>"
 
 #. module: website_compassion
+#: model_terms:ir.ui.view,arch_db:website_compassion.my_children_gift_history
+msgid "https://compassion.ch/de/geschenkformular"
+msgstr "https://compassion.ch/de/geschenkformular"
+
+#. module: website_compassion
 #: model_terms:ir.ui.view,arch_db:website_compassion.my_donations_gift_history
 msgid "<span>Open contributions</span>"
 msgstr "Offene Zahlungen"

--- a/website_compassion/i18n/de.po
+++ b/website_compassion/i18n/de.po
@@ -204,7 +204,8 @@ msgid "<span>Make a donation</span>"
 msgstr "Ein Geschenk machen<br/>"
 
 #. module: website_compassion
-#: model_terms:ir.ui.view,arch_db:website_compassion.my_children_gift_history
+#: code:addons/website_compassion/controllers/my_account.py:418
+#, python-format
 msgid "https://compassion.ch/de/geschenkformular"
 msgstr "https://compassion.ch/de/geschenkformular"
 

--- a/website_compassion/i18n/fr_CH.po
+++ b/website_compassion/i18n/fr_CH.po
@@ -202,7 +202,12 @@ msgstr "<span>Lettres</span>"
 #. module: website_compassion
 #: model_terms:ir.ui.view,arch_db:website_compassion.my_children_gift_history
 msgid "<span>Make a donation</span>"
-msgstr "<span>Faire un don</span>"
+msgstr "<span>Faire un cadeau</span>"
+
+#. module: website_compassion
+#: model_terms:ir.ui.view,arch_db:website_compassion.my_children_gift_history
+msgid "https://compassion.ch/de/geschenkformular"
+msgstr "https://compassion.ch/formulaire-pour-cadeau"
 
 #. module: website_compassion
 #: model_terms:ir.ui.view,arch_db:website_compassion.my_donations_gift_history

--- a/website_compassion/i18n/fr_CH.po
+++ b/website_compassion/i18n/fr_CH.po
@@ -205,7 +205,8 @@ msgid "<span>Make a donation</span>"
 msgstr "<span>Faire un cadeau</span>"
 
 #. module: website_compassion
-#: model_terms:ir.ui.view,arch_db:website_compassion.my_children_gift_history
+#: code:addons/website_compassion/controllers/my_account.py:418
+#, python-format
 msgid "https://compassion.ch/de/geschenkformular"
 msgstr "https://compassion.ch/formulaire-pour-cadeau"
 

--- a/website_compassion/i18n/it.po
+++ b/website_compassion/i18n/it.po
@@ -207,9 +207,10 @@ msgid "<span>Make a donation</span>"
 msgstr "Fai una donazione<br/>"
 
 #. module: website_compassion
-#: model_terms:ir.ui.view,arch_db:website_compassion.my_children_gift_history
+#: code:addons/website_compassion/controllers/my_account.py:418
+#, python-format
 msgid "https://compassion.ch/de/geschenkformular"
-msgstr "https://compassion.ch/it/formulario-per-regalo/"
+msgstr "https://compassion.ch/it/formulario-per-regalo"
 
 #. module: website_compassion
 #: model_terms:ir.ui.view,arch_db:website_compassion.my_donations_gift_history

--- a/website_compassion/i18n/it.po
+++ b/website_compassion/i18n/it.po
@@ -207,6 +207,11 @@ msgid "<span>Make a donation</span>"
 msgstr "Fai una donazione<br/>"
 
 #. module: website_compassion
+#: model_terms:ir.ui.view,arch_db:website_compassion.my_children_gift_history
+msgid "https://compassion.ch/de/geschenkformular"
+msgstr "https://compassion.ch/it/formulario-per-regalo/"
+
+#. module: website_compassion
 #: model_terms:ir.ui.view,arch_db:website_compassion.my_donations_gift_history
 msgid "<span>Open contributions</span>"
 msgstr "Fatture aperte"


### PR DESCRIPTION
- Added translation for the german "make-a-gift" URL in french and italian
- Changed "faire un don" to "faire un cadeau" in the french translation