### PR TITLE
Co-3940:  Assign call task to event ambassador if church rep

### DIFF
--- a/partner_communication_switzerland/__manifest__.py
+++ b/partner_communication_switzerland/__manifest__.py
@@ -37,6 +37,7 @@
     "depends": [
         "report_compassion",
         "child_switzerland",
+        "hr_switzerland",
         "theme_compassion",
         "sms_939",  # compassion-switzerland
         "auth_signup",  # source/addons


### PR DESCRIPTION
This PR aims at giving the call task in a waiting reminder 2 to the church rep ambassador of the event from which the contracts originated, if any.

From the communication job, retrieves the linked records if and only if they're recurring contracts, iterate over them to find an eventual related event through origin. Note that if there are multiple related contracts and that one of them has a church rep ambassador, he's used.

If an event is found, get the ambassador and find the related employee and its job. If he's a church rep, assign him the call task, otherwise assign it to the default user (previous behavior)