### PR TITLE
Co 3948 Warn upon create_sponsorship_job that fails

### DIFF
--- a/wordpress_connector/models/contracts.py
+++ b/wordpress_connector/models/contracts.py
@@ -329,7 +329,7 @@ class Contracts(models.Model):
             """Log the error and send a mail stating that it failed running"""
             _logger.error("Wordpress create sponsorship job failed", exc_info=True)
             child.activity_schedule(
-                'mail.mail_activity_data_todo',
+                'mail_activity_data_warning',
                 summary="[URGENT] Wordpress create sponsorship job failed",
                 note="Please verify this new sponsorship made from the website with "
                      f"following information: {form_data}, "

--- a/wordpress_connector/models/contracts.py
+++ b/wordpress_connector/models/contracts.py
@@ -222,7 +222,7 @@ class Contracts(models.Model):
             self.env.clear()
             # Notify staff
             child.activity_schedule(
-                'mail.mail_activity_data_todo',
+                'mail.mail_activity_data_warning',
                 summary="[URGENT] Sponsorship from website failed",
                 note="Please verify this new sponsorship made from the website with "
                      f"following information: {form_data} lang: {sponsor_lang} "

--- a/wordpress_connector/models/contracts.py
+++ b/wordpress_connector/models/contracts.py
@@ -332,8 +332,8 @@ class Contracts(models.Model):
                 'mail_activity_data_warning',
                 summary="[URGENT] Wordpress create sponsorship job failed",
                 note="Please verify this new sponsorship made from the website with "
-                     f"following information: {form_data}, "
-                     f"and given following values: {values}, "
-                     f"with following error: {err}",
+                     f"following information: {str(form_data)}, "
+                     f"and given following values: {str(values)}, "
+                     f"with following error: {str(err)}",
                 user_id=21  # EMA
             )


### PR DESCRIPTION
Not sure if this is the correct approach, did not find any reference to opsgenie in code but rather sending emails so reproduced it here.

This commit adds code to catch any error occuring in the create_sponsorship_job method of the wordpress connector and sends an email notifying of the problem.