### PR TITLE
Co 3971: reference textuel pour des contrat avec virement

### DIFF
--- a/sponsorship_switzerland/data/completion_rules.xml
+++ b/sponsorship_switzerland/data/completion_rules.xml
@@ -25,6 +25,12 @@
         <field name="function_to_call">get_from_lsv_dd</field>
     </record>
 
+    <record id="bank_statement_completion_rule_recurring_contract_wire_transfer_mapping" model="account.statement.completion.rule">
+        <field name="name">Match wire transfer payment mode custom ref</field>
+        <field name="sequence">20</field>
+        <field name="function_to_call">recurring_contract_wire_transfer_mapping</field>
+    </record>
+
     <record id="bank_statement_completion_rule_sponsor_name" model="account.statement.completion.rule">
         <field name="name">Match sponsor name (based on label)</field>
         <field name="sequence">90</field>

--- a/sponsorship_switzerland/models/completion_rules.py
+++ b/sponsorship_switzerland/models/completion_rules.py
@@ -152,7 +152,6 @@ class StatementCompletionRule(models.Model):
             return res
 
         recurring_contract_groups = self.env['recurring.contract.group'].search([
-            "&",
             ("bvr_reference", "!=", False),
             ("payment_mode_id", "=", wire_transfer_mode.id)
         ]).filtered(lambda it: name.startswith(it.bvr_reference))

--- a/sponsorship_switzerland/models/completion_rules.py
+++ b/sponsorship_switzerland/models/completion_rules.py
@@ -143,7 +143,7 @@ class StatementCompletionRule(models.Model):
         name = st_line['name']
         res = dict()
 
-        wire_transfer_mode = self.env['account.payment.mode'].search([
+        wire_transfer_mode = self.env['account.payment.mode'].with_context(lang="en_US").search([
             ("name", "=", "wire transfer")
         ])
 

--- a/sponsorship_switzerland/models/completion_rules.py
+++ b/sponsorship_switzerland/models/completion_rules.py
@@ -157,7 +157,7 @@ class StatementCompletionRule(models.Model):
         ]).filtered(lambda it: name.startswith(it.bvr_reference))
 
         if recurring_contract_groups:
-            res['partner_id'] = recurring_contract_groups.partner_id
+            res['partner_id'] = recurring_contract_groups[0].partner_id
 
         return res
 

--- a/sponsorship_switzerland/models/contract_group.py
+++ b/sponsorship_switzerland/models/contract_group.py
@@ -22,7 +22,7 @@ class ContractGroup(models.Model):
     ##########################################################################
     #                                 FIELDS                                 #
     ##########################################################################
-    bvr_reference = fields.Char("BVR Ref", size=32, track_visibility="onchange")
+    bvr_reference = fields.Char("BVR Ref", size=150, track_visibility="onchange")
     payment_mode_id = fields.Many2one(
         default=lambda self: self._get_op_payment_mode(), readonly=False
     )
@@ -189,6 +189,13 @@ class ContractGroup(models.Model):
     def on_change_bvr_ref(self):
         """ Test the validity of a reference number. """
         bvr_reference = self.bvr_reference
+
+        # Omit check if payment mode is wire transfer so that we can manually
+        # create recurring contracts based on recurrent payment a partner does
+        # reference: CO-3971
+        if self.payment_mode_id.name == 'wire transfer':
+            return
+
         is_valid = bvr_reference and bvr_reference.isdigit()
         if is_valid and len(bvr_reference) == 26:
             bvr_reference = mod10r(bvr_reference)

--- a/sponsorship_switzerland/models/contract_group.py
+++ b/sponsorship_switzerland/models/contract_group.py
@@ -193,7 +193,7 @@ class ContractGroup(models.Model):
         # Omit check if payment mode is wire transfer so that we can manually
         # create recurring contracts based on recurrent payment a partner does
         # reference: CO-3971
-        if self.payment_mode_id.name == 'wire transfer':
+        if self.payment_mode_id.with_context(lang="en_US").name == 'wire transfer':
             return
 
         is_valid = bvr_reference and bvr_reference.isdigit()


### PR DESCRIPTION
This PR adds the possibility to create recurring contracts that are automatically reconcilied with recurring payments from a sponsor/donor.

To use it:
- Check in the bank statement line the "label", and copy the beginning of it, enough to be unique
- Create a new recurring contract for the donor
- Set the payment option to "wire transfer", this allows you to set any BVR reference, put the copied beginning of the bank statement label

Please note:
I am absolutely NOT sure about the sequence of the completion rule, I put 20 because it worked in my tests... Sometimes my completion rule was not checked because another more important one yielded a result before.