### PR TITLE
FIX: correct pictures condition

### DIFF
--- a/report_compassion/report/ending_sponsorship_certificate.xml
+++ b/report_compassion/report/ending_sponsorship_certificate.xml
@@ -106,7 +106,7 @@
             <t t-foreach="docs" t-as="o">
                 <t t-call="report_compassion.style"/>
                 <t t-set="pictures" t-value="o.child_id.pictures_ids"/>
-                <t t-set="first_pic_available" t-value="len(pictures) &gt; 1 and pictures[-1].date.year &gt;= o.start_date.year"/>
+                <t t-set="first_pic_available" t-value="len(pictures) &gt; 1 and pictures[-1].date.year &gt;= o.start_date.year and pictures[-1].date.year &lt; pictures[0].date.year"/>
                 <div class="background" t-if="digital">
                     <img t-attf-src="#{base_url}/report_compassion/static/img/report_compassion.ending_sponsorship_certificate/ending_sponsor_card_#{lang[:2]}.jpg"/>
                 </div>

--- a/report_compassion/report/ending_sponsorship_certificate.xml
+++ b/report_compassion/report/ending_sponsorship_certificate.xml
@@ -106,7 +106,7 @@
             <t t-foreach="docs" t-as="o">
                 <t t-call="report_compassion.style"/>
                 <t t-set="pictures" t-value="o.child_id.pictures_ids"/>
-                <t t-set="first_pic_available" t-value="len(pictures) &gt; 1 and pictures[-1].date.year == o.start_date.year"/>
+                <t t-set="first_pic_available" t-value="len(pictures) &gt; 1 and pictures[-1].date.year &gt;= o.start_date.year"/>
                 <div class="background" t-if="digital">
                     <img t-attf-src="#{base_url}/report_compassion/static/img/report_compassion.ending_sponsorship_certificate/ending_sponsor_card_#{lang[:2]}.jpg"/>
                 </div>


### PR DESCRIPTION
The SDS reported a problem with the generation of the sponsorship certificates. [CP-236](https://compassion-ch.atlassian.net/browse/CP-236)

In many cases, there wasn't 2 pictures in the certificate even if the child was having many pictures. 

The XML condition was checking the exact date of the pictures, but in many cases, the first picture year of the child is greater then the contract start year.