### PR TITLE
12.0 fix qr without address

### DIFF
--- a/partner_compassion/models/partner_bank_compassion.py
+++ b/partner_compassion/models/partner_bank_compassion.py
@@ -23,16 +23,28 @@ class ResPartnerBank(models.Model):
         and can't be empty to be allowed in post offices.
         This function is a workaround to this problem.
         We also ensure that the amount is in the range specified by the swiss qr specifications.
+        Furthermore, when the debtor partner isn't set correctly, we do not declare its information in the QR
+        to avoid errors on the user e-banking side.
         """
-        must_be_corrected = type(amount) not in [int, float] or not (0.01 <= amount <= 999999999.99)
-        if not must_be_corrected:
-            return super().build_swiss_code_vals(amount, *args)
-
-        amount = -3141592.64 # dummy value
         qr_code_vals = super().build_swiss_code_vals(amount, *args)
-        # ensure that this position is still the amount
-        assert qr_code_vals[18] == f"{amount:.2f}"
-        qr_code_vals[18] = ""
+
+        must_be_corrected = type(amount) not in [int, float] or not (0.01 <= amount <= 999999999.99)
+
+        if must_be_corrected:
+            amount = -3141592.64  # dummy value
+            qr_code_vals = super().build_swiss_code_vals(amount, *args)
+            # ensure that this position is still the amount
+            assert qr_code_vals[18] == f"{amount:.2f}"
+            qr_code_vals[18] = ""
+
+        # Set the debtor's value as nothing to escape scanning errors when the debtors information is not set correctly
+        if False in [args[2].city, args[2].zip, args[2].country_id.code]:
+            qr_code_vals[20] = ''  # Ultimate Debtor Address Type
+            qr_code_vals[21] = ''  # Ultimate Debtor Name
+            qr_code_vals[22] = ''  # Ultimate Debtor Address Line 1
+            qr_code_vals[23] = ''  # Ultimate Debtor Address Line 2
+            qr_code_vals[26] = ''  # Ultimate Debtor Postal Country
+
         return qr_code_vals
 
     def validate_swiss_code_arguments(self, currency, debtor_partner, reference_to_check=''):

--- a/partner_compassion/models/partner_bank_compassion.py
+++ b/partner_compassion/models/partner_bank_compassion.py
@@ -35,6 +35,14 @@ class ResPartnerBank(models.Model):
         qr_code_vals[18] = ""
         return qr_code_vals
 
+    def validate_swiss_code_arguments(self, currency, debtor_partner, reference_to_check=''):
+        """Override this function to let the creation of QR invoices without partner's information
+           As we can have partners without an address set we get rid of the inner function _partner_fields_set.
+        """
+        return (reference_to_check == '' or not self._is_qr_iban()
+                or self._is_qr_reference(reference_to_check))
+
+
     @api.model
     def create(self, data):
         """Override function to notify creation in a message


### PR DESCRIPTION
Related Issue : [CP-297](https://compassion-ch.atlassian.net/browse/CP-297)

This correction let an invoice to be generated even if the related partner (debtor partner) has no address information.

The QR values are build in the module l10n_ch/models/res_bank.py. 
First I have override the related function `validate_swiss_code_arguments()` to let it pass a debtor partner without any valid address information. 

Then I have modified the code related to the check on the amount so it allows me to change the values in the array `qr_code_vals[]`.

Finally I added a check on the partner's required information for the QR and if any of these is not set, we set the QR value with nothing in the related array fields. A QR without these information will be processed as paid from the banking account that paid it instead of the debtor's information set during the payment.
 