### PR TITLE
FIX: remove obsolete code handling duplex

### DIFF
--- a/partner_communication_switzerland/models/partner_communication.py
+++ b/partner_communication_switzerland/models/partner_communication.py
@@ -70,22 +70,6 @@ class PartnerCommunication(models.Model):
 
         super(PartnerCommunication, self.sudo(user_id)).schedule_call()
 
-    def print_letter(self, print_name, **print_options):
-        """
-        Adds duplex printing option for Konica Minolta depending on page count.
-        """
-        if len(self) > 1:
-            page_counts = list(set(self.mapped("pdf_page_count")))
-            # Duplex if all documents have a pair page count
-            sided_option = "2sided"
-            for p_count in page_counts: 
-                if p_count % 2 != 0:
-                    sided_option = "1Sided"
-                    break
-            print_options["KMDuplex"] = sided_option
-
-        return super().print_letter(print_name, **print_options)
-
     @api.model
     def send_mode_select(self):
         modes = super().send_mode_select()


### PR DESCRIPTION
_Related Issue: T0075 - Print reminder print duplex_

Remove obsolete code that was used with our previous printer,

With the code changes on the related pull request, it is now possible to set the printer options directly in the concerning Odoo report. 

Related Pull Request: [1729](https://github.com/CompassionCH/compassion-modules/pull/1729), [5](https://github.com/CompassionCH/report-print-send/pull/5)