### PR TITLE
T0168 interaction resume add a full time one

### DIFF
--- a/sms_939/models/interaction_resume_sms.py
+++ b/sms_939/models/interaction_resume_sms.py
@@ -13,13 +13,14 @@ class InteractionResume(models.TransientModel):
     _inherit = "interaction.resume"
 
     @api.model
-    def populate_resume(self, partner_id):
+    def populate_resume(self, partner_id, full=False):
         """
         Creates the rows for the resume of given partner
         :param partner_id: the partner
+        :param full: define the timebase on the interactions
         :return: True
         """
-        res = super().populate_resume(partner_id)
+        res = super().populate_resume(partner_id, full)
         self.env.cr.execute(
             f"""
               SELECT


### PR DESCRIPTION
This commits add the button to open a full time interaction_resume. Improvement possible: Add a setting preference that would allow the users to define what button they want to see on the interface (both (full/newest) or only one of them they prefer).