### PR TITLE
the number of children is now parametrable in settings

### DIFF
--- a/child_sync_wp/__manifest__.py
+++ b/child_sync_wp/__manifest__.py
@@ -29,7 +29,7 @@
 # pylint: disable=C8101
 {
     "name": "Sync Compassion Children with Wordpress website",
-    "version": "14.0.0.0.0",
+    "version": "14.0.0.0.1",
     "category": "Compassion",
     "author": "Compassion CH",
     "license": "AGPL-3",

--- a/child_sync_wp/data/wordpress_cron.xml
+++ b/child_sync_wp/data/wordpress_cron.xml
@@ -6,7 +6,7 @@
 -->
 <odoo>
     <data noupdate="1">
-        <record id="refersh_wordpress_cron" model="ir.cron">
+        <record id="refresh_wordpress_cron" model="ir.cron">
             <field name="name">Refresh children on Wordpress</field>
             <field name="interval_number">1</field>
             <field name="interval_type">weeks</field>

--- a/child_sync_wp/migrations/14.0.0.0.1/post-migration.py
+++ b/child_sync_wp/migrations/14.0.0.0.1/post-migration.py
@@ -1,0 +1,18 @@
+import logging
+from odoo import api, SUPERUSER_ID, registry
+from odoo.tools.convert import convert_file
+
+logger = logging.getLogger(__name__)
+
+def migrate_data(cr):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+
+    # Path to your XML file
+    xml_file_path = 'data/wordpress_cron.xml'
+
+    try:
+        # Convert and load the XML file
+        convert_file(cr, 'child_sync_wp', xml_file_path, {}, 'init', {}, {})
+        logger.info(f"Successfully loaded {xml_file_path}")
+    except Exception as e:
+        logger.error(f"Error loading {xml_file_path}: {str(e)}")

--- a/partner_compassion/data/partner_category_data.xml
+++ b/partner_compassion/data/partner_category_data.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
-    <data noupdate="True">
+    <data noupdate="1">
 
         <!--
         Resource: res.partner.category

--- a/partner_compassion/data/partner_title_data.xml
+++ b/partner_compassion/data/partner_title_data.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
-    <data noupdate="True">
+    <data noupdate="1">
         <record id="res_partner_title_men" model="res.partner.title">
             <field name="name">Misters</field>
             <field name="shortcut">Messrs.</field>


### PR DESCRIPTION
changed the cron refresh_wordpress_cron() in child_sync_wp/models/child_compassion.py to fetch the Number Children Website setting from Settings->Compassion->Demand Planning->Allocation per week. Also corected the wordpres_cron.xml and added migration scipt to reload the xml data.