### PR TITLE
[T1506] Add employee image as link in email's signature 

### DIFF
--- a/partner_communication_switzerland/controllers/__init__.py
+++ b/partner_communication_switzerland/controllers/__init__.py
@@ -8,5 +8,6 @@
 #
 ##############################################################################
 from . import b2s_image
+from . import employee_image
 from . import zoom_registration
 from . import onboarding

--- a/partner_communication_switzerland/controllers/employee_image.py
+++ b/partner_communication_switzerland/controllers/employee_image.py
@@ -7,46 +7,41 @@
 #    The licence is in the file __manifest__.py
 #
 ##############################################################################
+import base64
+
+from werkzeug.exceptions import NotFound
+
 from odoo import http
 from odoo.http import request
-from werkzeug.exceptions import NotFound
-import base64
 
 
 class EmployeeImageController(http.Controller):
-    @http.route(
-        '/employee/image/<int:employee_id>/',
-        auth='public',
-        type='http',
-        methods=["GET"],
-        website=True,
-        sitemap=False
-    )
+    @http.route("/employee/image/<int:employee_id>/", auth="public")
     def get_employee_image(self, employee_id):
         """
         Retrieves the image for a given employee ID and returns it as a PNG image.
 
         Args:
-            employee_id (int): The unique identifier of the employee whose image is requested.
+            employee_id (int)
 
         Returns:
-            werkzeug.wrappers.Response: A response object containing the binary image data,
+            werkzeug.wrappers.Response: A response object with the binary image data
 
         Raises:
             werkzeug.exceptions.NotFound
         """
-        employee = request.env['hr.employee'].sudo().browse(employee_id)
+        employee = request.env["hr.employee"].sudo().browse(employee_id)
         if not employee.image_128:
             raise NotFound()
 
         # Decode the base64 image as binary image
         image_data = base64.b64decode(employee.image_128)
 
-        # Return the binary image directly in the browser
+        # Return the binary image directly as response
         return request.make_response(
             image_data,
             headers=[
-                ('Content-Type', 'image/png'),
-                ('Content-Disposition', 'inline; filename="employee_image.png"'),
-            ]
+                ("Content-Type", "image/png"),
+                ("Content-Disposition", 'inline; filename="employee_image.png"'),
+            ],
         )

--- a/partner_communication_switzerland/controllers/employee_image.py
+++ b/partner_communication_switzerland/controllers/employee_image.py
@@ -1,0 +1,52 @@
+##############################################################################
+#
+#    Copyright (C) 2024 Compassion CH (http://www.compassion.ch)
+#    Releasing children from poverty in Jesus' name
+#    @author: Noé Berdoz <nberdoz@compassion.ch>
+#
+#    The licence is in the file __manifest__.py
+#
+##############################################################################
+from odoo import http
+from odoo.http import request
+from werkzeug.exceptions import NotFound
+import base64
+
+
+class EmployeeImageController(http.Controller):
+    @http.route(
+        '/employee/image/<int:employee_id>/',
+        auth='public',
+        type='http',
+        methods=["GET"],
+        website=True,
+        sitemap=False
+    )
+    def get_employee_image(self, employee_id):
+        """
+        Retrieves the image for a given employee ID and returns it as a PNG image.
+
+        Args:
+            employee_id (int): The unique identifier of the employee whose image is requested.
+
+        Returns:
+            werkzeug.wrappers.Response: A response object containing the binary image data,
+
+        Raises:
+            werkzeug.exceptions.NotFound
+        """
+        employee = request.env['hr.employee'].sudo().browse(employee_id)
+        if not employee.image_128:
+            raise NotFound()
+
+        # Decode the base64 image as binary image
+        image_data = base64.b64decode(employee.image_128)
+
+        # Return the binary image directly in the browser
+        return request.make_response(
+            image_data,
+            headers=[
+                ('Content-Type', 'image/png'),
+                ('Content-Disposition', 'inline; filename="employee_image.png"'),
+            ]
+        )

--- a/partner_communication_switzerland/models/res_users.py
+++ b/partner_communication_switzerland/models/res_users.py
@@ -64,10 +64,9 @@ class ResUsers(models.Model):
                 "en_US": "https://www.facebook.com/compassionsuisse/",
             }
             lang = self.env.lang or self._context.get("lang") or self.env.user.lang
-            base_url = self.env['ir.config_parameter'].sudo().get_param('web.base.url')
+            base_url = self.env["ir.config_parameter"].sudo().get_param("web.base.url")
 
             for user in self:
-
                 employee = user.employee_ids[:1].with_context(bin_size=False)
                 employee_image_url = f"{base_url}/employee/image/{employee.id}"
 
@@ -89,7 +88,7 @@ class ResUsers(models.Model):
                     .replace(" ", "")
                     .replace("(0)", ""),
                     "facebook": facebook.get(lang),
-                    "employee_image_url": employee_image_url
+                    "employee_image_url": employee_image_url,
                 }
                 if lang in ("fr_CH", "en_US"):
                     template.remove("#bern")

--- a/partner_communication_switzerland/models/res_users.py
+++ b/partner_communication_switzerland/models/res_users.py
@@ -64,9 +64,13 @@ class ResUsers(models.Model):
                 "en_US": "https://www.facebook.com/compassionsuisse/",
             }
             lang = self.env.lang or self._context.get("lang") or self.env.user.lang
+            base_url = self.env['ir.config_parameter'].sudo().get_param('web.base.url')
+
             for user in self:
+
                 employee = user.employee_ids[:1].with_context(bin_size=False)
-                photo = employee.image_128
+                employee_image_url = f"{base_url}/employee/image/{employee.id}"
+
                 values = {
                     "name": f"{user.preferred_name} {user.lastname}"
                     if user.firstname
@@ -85,16 +89,12 @@ class ResUsers(models.Model):
                     .replace(" ", "")
                     .replace("(0)", ""),
                     "facebook": facebook.get(lang),
-                    "photo": photo.decode("utf-8")
-                    if isinstance(photo, bytes)
-                    else photo,
+                    "employee_image_url": employee_image_url
                 }
                 if lang in ("fr_CH", "en_US"):
                     template.remove("#bern")
                 else:
                     template.remove("#yverdon")
-                if not photo:
-                    template.remove("#photo")
                 if not employee.mobile_phone:
                     template.remove(".work_mobile")
                 user.signature = template.html().format(**values)

--- a/partner_communication_switzerland/static/html/signature.html
+++ b/partner_communication_switzerland/static/html/signature.html
@@ -19,7 +19,7 @@
                 id="photo"
               >
                 <img
-                  src="data:image/png;base64,{photo}"
+                  src="{employee_image_url}"
                   width="74"
                   valign="top"
                   alt="photo-logo"


### PR DESCRIPTION
Related ticket: [T1506](https://erp.compassion.ch/web#id=2098&action=521&active_id=895&model=project.task&view_type=form&cids=1&menu_id=2029)

This PR changes how the employee signature image is handled when sending an email.
Instead of using a base64 encoded image to display the employee image, it retrieves the it from a new created endpoint 
**/employee/image/:employee_id.**

This change is needed because integrated base64 encoded image are not supported by many mail clients, as for example Gmail.