### PR TITLE
[T1565] Fix QR invoices with no amount

### DIFF
--- a/partner_compassion/__manifest__.py
+++ b/partner_compassion/__manifest__.py
@@ -37,6 +37,7 @@
     "license": "AGPL-3",
     "website": "https://github.com/CompassionCH/compassion-switzerland",
     "depends": [
+        "l10n_ch",
         "mail",
         # compassion-modules
         "crm_compassion",

--- a/partner_compassion/models/partner_bank_compassion.py
+++ b/partner_compassion/models/partner_bank_compassion.py
@@ -3,6 +3,7 @@
 #    Copyright (C) 2014-2015 Compassion CH (http://www.compassion.ch)
 #    Releasing children from poverty in Jesus' name
 #    @author: Steve Ferry
+#    @author: Noé Berdoz <nberdoz@compasion.ch>
 #
 #    The licence is in the file __manifest__.py
 #
@@ -16,6 +17,30 @@ class ResPartnerBank(models.Model):
     """This class upgrade the partners.bank to match Compassion needs."""
 
     _inherit = "res.partner.bank"
+
+    def _l10n_ch_get_qr_vals(
+        self,
+        amount,
+        currency_name,
+        debtor_partner,
+        free_communication,
+        structured_communication,
+    ):
+        """
+        Returns a list of values for a Swiss QR bill.
+        Allows invoices with no amount to let the payer choose the amount to pay.
+        """
+        qr_vals = super()._l10n_ch_get_qr_vals(
+            amount,
+            currency_name,
+            debtor_partner,
+            free_communication,
+            structured_communication,
+        )
+        # Set amount to an empty string indicating that it has to be chosen by the payer
+        qr_vals[18] = "" if qr_vals[18] == "0.00" else qr_vals[18]
+
+        return qr_vals
 
     def _get_partner_address_lines(self, partner):
         """Override to allow empty zip or city."""


### PR DESCRIPTION
In the migration from 12 to 14, we lost our functionality allowing a QR invoice with no amount to let the payer choose the amount to pay.

This PR adds it back  

It's close to the way Odoo is doing it in 17: [l10n-switzerland related code](https://github.com/OCA/l10n-switzerland/blob/17.0/l10n_ch_qr_no_amount/models/res_partner_bank.py)