### PR TITLE
T1502 - Add 'PDF' to action that prints sponsorship pdf format

### DIFF
--- a/report_compassion/views/print_sponsorship_bvr_view.xml
+++ b/report_compassion/views/print_sponsorship_bvr_view.xml
@@ -77,7 +77,7 @@
     </record>
 
     <record id="action_print_sponsorship_bvr_due" model="ir.actions.act_window">
-         <field name="name">Sponsorship Due</field>
+         <field name="name">Sponsorship Due PDF</field>
          <field name="res_model">print.sponsorship.bvr.due</field>
          <field name="type">ir.actions.act_window</field>
          <field name="view_mode">form</field>


### PR DESCRIPTION
# Description
In the "Sponsorphip" page there are two buttons that allow the user to print the "Sponsorship Due". However both buttons have the same text even if one of them allows to print in PDF.

![347878595-0c8133ea-b852-4712-9ff7-38db59e9ffb9](https://github.com/CompassionCH/compassion-switzerland/assets/11978056/91b0c7bd-bb94-43a4-80dc-d274b673385b)

# Technical Aspects
The fix is simply changing the name of the action that prints in pdf to distinguish it.
