### PR TITLE
T1689 - support layout problem

### DIFF
--- a/partner_communication_switzerland/static/scss/chatter_emails.scss
+++ b/partner_communication_switzerland/static/scss/chatter_emails.scss
@@ -1,4 +1,4 @@
 // Prevents pre elements inside emails from overflowing the email message.
 .o_Message_prettyBody pre {
-    white-space: pre-wrap;
+  white-space: pre-wrap;
 }

--- a/partner_communication_switzerland/static/scss/chatter_emails.scss
+++ b/partner_communication_switzerland/static/scss/chatter_emails.scss
@@ -1,0 +1,4 @@
+// Prevents pre elements inside emails from overflowing the email message.
+.o_Message_prettyBody pre {
+    white-space: pre-wrap;
+}

--- a/partner_communication_switzerland/views/assets.xml
+++ b/partner_communication_switzerland/views/assets.xml
@@ -6,6 +6,10 @@
           rel="stylesheet"
           href="/partner_communication_switzerland/static/scss/html_fields.scss"
         />
+                <link
+          rel="stylesheet"
+          href="/partner_communication_switzerland/static/scss/chatter_emails.scss"
+        />
             </xpath>
         </template>
         <template id="assets_frontend" inherit_id="web.assets_frontend">


### PR DESCRIPTION
- `<pre>` tags cause the chatter to overflow and display a horizontal scrollbar. As most emails are inside `<pre>`, allow line breaks inside `<pre>` in the chatter window. 

#### Example on real support email anonymized

Before with overflow:
![image](https://github.com/user-attachments/assets/63a01fbb-7b94-4857-b7a8-da974ee58a08)

After without overflow:
![image](https://github.com/user-attachments/assets/fa6f452c-b035-48fa-bb79-993bc1be5148)
