### PR TITLE
T1767 - Funds partner matching

### DIFF
--- a/wordpress_connector/models/account_invoice.py
+++ b/wordpress_connector/models/account_invoice.py
@@ -9,7 +9,7 @@
 ##############################################################################
 import logging
 
-import markupsafe
+from markupsafe import escape
 
 from odoo import api, fields, models
 
@@ -27,7 +27,7 @@ class AccountInvoice(models.Model):
         """
         _logger.info("Processing donation from WordPress %s", str(donnation_infos))
         for key in donnation_infos:
-            donnation_infos[key] = markupsafe.escape(donnation_infos[key])
+            donnation_infos[key] = escape(donnation_infos[key])
 
         match_obj = self.env["res.partner.match.wp"]
 

--- a/wordpress_connector/models/account_invoice.py
+++ b/wordpress_connector/models/account_invoice.py
@@ -9,7 +9,7 @@
 ##############################################################################
 import logging
 
-from werkzeug.utils import escape
+import markupsafe
 
 from odoo import api, fields, models
 
@@ -27,7 +27,7 @@ class AccountInvoice(models.Model):
         """
         _logger.info("Processing donation from WordPress %s", str(donnation_infos))
         for key in donnation_infos:
-            donnation_infos[key] = escape(donnation_infos[key])
+            donnation_infos[key] = markupsafe.escape(donnation_infos[key])
 
         match_obj = self.env["res.partner.match.wp"]
 

--- a/wordpress_connector/models/match_partner_wp.py
+++ b/wordpress_connector/models/match_partner_wp.py
@@ -8,7 +8,11 @@
 #
 ##############################################################################
 
+import logging
+
 from odoo import api, models
+
+_logger = logging.getLogger(__name__)
 
 LANG_MAPPING = {"fr": "fr_CH", "de": "de_DE", "it": "it_IT"}
 
@@ -87,15 +91,22 @@ class MatchPartnerWP(models.AbstractModel):
 
     @api.model
     def _match_rule_child_id(self, partner_obj, infos=None, options=None):
-        # if a keyerror is raise it is handled as "no child found go to next rule"
+        # if a keyerror is raised it is handled as "no child found go to next rule"
         child_local_id = infos.pop("child_id") if infos else partner_obj.pop("child_id")
         if child_local_id:
             child = self.env["compassion.child"].search(
                 [("local_id", "ilike", child_local_id)]
             )
             if child:
-                sponsorship = self.env["recurring.contract"].search(
-                    [("child_id", "=", child.id)], limit=1
-                )
-                return sponsorship[sponsorship.send_gifts_to]
+                if len(child) > 1:
+                    # Too many matches, the local ID was loose.
+                    _logger.warning(
+                        "Child local_id is specified but was ignored as it matched "
+                        "multiple children."
+                    )
+                else:
+                    sponsorship = self.env["recurring.contract"].search(
+                        [("child_id", "=", child.id)], limit=1
+                    )
+                    return sponsorship[sponsorship.send_gifts_to]
         return self.env["res.partner"]


### PR DESCRIPTION
- If the `child_id` is missing characters, it can match multiple children and result in an internal server error. In this case, the `child_id` is ignored. If the website supports it, it might be better to raise a specific exception displayed for the user notifying that the `child_id` is invalid if they specified one.
- Replace deprecated call to `werkzeug.utils.escape` by a call to `markupsafe.escape` as recommended by the warning message.