### PR TITLE
T1763 - Change how donations are displayed in cart

### DIFF
--- a/website_switzerland/controllers/website_sale.py
+++ b/website_switzerland/controllers/website_sale.py
@@ -28,3 +28,18 @@ class WebsiteSaleWithoutState(WebsiteSale):
         if request.env.lang == "it_IT":
             legal_link = "https://compassion.ch/it/privacy-e-termini//"
         return request.redirect(legal_link, code=301)
+
+    def _get_mandatory_fields_billing(self, country_id=False):
+        req = super()._get_mandatory_fields_billing(country_id)
+        self._filter_mandatory_fields(req)
+        return req
+
+    def _get_mandatory_fields_shipping(self, country_id=False):
+        req = super()._get_mandatory_fields_shipping(country_id)
+        self._filter_mandatory_fields(req)
+        return req
+
+    def _filter_mandatory_fields(self, req):
+        # Field is removed from view, we can't require it.
+        if "state_id" in req:
+            req.remove("state_id")

--- a/website_switzerland/templates/website_cart.xml
+++ b/website_switzerland/templates/website_cart.xml
@@ -76,4 +76,15 @@
             </td>
         </xpath>
     </template>
+    <!-- Convert to int when displaying if we can to avoid floating point precision issues. -->
+    <template id="cart_lines" inherit_id="website_sale.cart_lines">
+        <xpath
+      expr="//table[@id='cart_products']/tbody/t/tr/td[hasclass('td-qty')]/div/input"
+      position="attributes"
+    >
+            <attribute
+        name="t-att-value"
+      >round(line.product_uom_qty, 5) == int(line.product_uom_qty) and int(line.product_uom_qty) or line.product_uom_qty</attribute>
+        </xpath>
+    </template>
 </odoo>

--- a/website_switzerland/templates/website_cart.xml
+++ b/website_switzerland/templates/website_cart.xml
@@ -64,5 +64,16 @@
         class="rounded o_image_64_max"
       />
         </xpath>
+        <!-- Remove trailing decimal notation when quantity is an integer. -->
+        <xpath
+      expr="//table[@id='cart_products']/tbody/tr/td[hasclass('td-qty')]"
+      position="replace"
+    >
+            <td class='td-qty' align="center">
+                <div
+          t-esc="int(line.product_uom_qty) if line.product_uom_qty.is_integer() else line.product_uom_qty"
+        />
+            </td>
+        </xpath>
     </template>
 </odoo>


### PR DESCRIPTION
Solves a few bugs found when doing T1763
- In the address form, the field `state_id` is forcefully hidden, but it is still required by some countries (like Argentina). The message `Some fields are missing` is shown even if all displayed fields are filled and the user can't proceed. Make this field optional when checking the form inputs.
- Remove decimal trailing `0` in quantity when the quantity is an integer and center the number:
![image](https://github.com/user-attachments/assets/e55a763e-37f6-4287-a478-e4496c4e4110)
![image](https://github.com/user-attachments/assets/99f431f3-85bd-4b6c-8bed-0093b2bc16b0)
- Fix a floating point precision display issue in the cart: 
![image](https://github.com/user-attachments/assets/986747dc-5703-441c-bd03-754139c04a8e)
![image](https://github.com/user-attachments/assets/9f869048-71b1-4d2f-b266-a366eecba87a)

