### PR TITLE
feat: display invoice date on sponsorship invoice tree

### DIFF
--- a/account_switzerland/views/account_move.xml
+++ b/account_switzerland/views/account_move.xml
@@ -98,6 +98,10 @@
         <field name="name">account.invoice.tree.inherit</field>
         <field name="model">account.move</field>
         <field name="inherit_id" ref="account.view_invoice_tree" />
+         <xpath expr="//field[@name='invoice_date']" position="attributes">
+            <attribute name="string">Invoice Date</attribute>
+            <attribute name="invisible">0</attribute>
+        </xpath>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='invoice_date_due']" position="after">
                 <field name="last_payment" />


### PR DESCRIPTION
This commit modifies the visibility in account.view_invoice_tree to display the invoice date in the sponsorship invoice tree view.