### PR TITLE
T1574 - Fix contact parent (1/2)

### DIFF
--- a/partner_compassion/__manifest__.py
+++ b/partner_compassion/__manifest__.py
@@ -30,7 +30,7 @@
 {
     "name": "Compassion CH Partners",
     "summary": "Upgrade Partners for Compassion Switzerland",
-    "version": "14.0.1.0.1",
+    "version": "14.0.1.0.2",
     "development_status": "Production/Stable",
     "category": "Partner Management",
     "author": "Compassion CH",

--- a/partner_compassion/migrations/14.0.1.0.2/post-migrate.py
+++ b/partner_compassion/migrations/14.0.1.0.2/post-migrate.py
@@ -1,0 +1,41 @@
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.logged_query(
+        env.cr,
+        """
+        UPDATE res_partner rp
+        SET city_id = rc.id 
+        FROM res_city rc
+        WHERE rp.city = rc.name 
+            AND rp.country_id = rc.country_id
+            AND rp.state_id = rc.state_id
+            AND rp.city_id IS NULL
+            AND rp.parent_id IS NULL;
+        """,
+    )
+    openupgrade.logged_query(
+        env.cr,
+        """
+        UPDATE res_partner rp 
+        SET zip_id=rcz.id 
+        FROM res_city_zip rcz
+        WHERE rp.city_id = res_city_zip.city_id 
+            AND rp.zip = rcz.name
+            AND rp.zip_id IS NULL
+            AND rp.parent_id IS NULL;
+        """,
+    )
+    openupgrade.logged_query(
+        env.cr,
+        """
+        UPDATE res_partner rp 
+        SET zip_id = rp_parent.zip_id, city_id = rp_parent.city_id
+        FROM (
+            SELECT zip_id, city_id 
+            FROM res_partner) rp_parent
+        WHERE rp.parent_id = rp_parent.id;
+        """,
+    )

--- a/partner_compassion/migrations/14.0.1.0.2/post-migrate.py
+++ b/partner_compassion/migrations/14.0.1.0.2/post-migrate.py
@@ -7,9 +7,9 @@ def migrate(env, version):
         env.cr,
         """
         UPDATE res_partner rp
-        SET city_id = rc.id 
+        SET city_id = rc.id
         FROM res_city rc
-        WHERE rp.city = rc.name 
+        WHERE rp.city = rc.name
             AND rp.country_id = rc.country_id
             AND rp.state_id = rc.state_id
             AND rp.city_id IS NULL
@@ -19,10 +19,10 @@ def migrate(env, version):
     openupgrade.logged_query(
         env.cr,
         """
-        UPDATE res_partner rp 
-        SET zip_id=rcz.id 
+        UPDATE res_partner rp
+        SET zip_id=rcz.id
         FROM res_city_zip rcz
-        WHERE rp.city_id = rcz.city_id 
+        WHERE rp.city_id = rcz.city_id
             AND rp.zip = rcz.name
             AND rp.zip_id IS NULL
             AND rp.parent_id IS NULL;
@@ -31,10 +31,10 @@ def migrate(env, version):
     openupgrade.logged_query(
         env.cr,
         """
-        UPDATE res_partner rp 
+        UPDATE res_partner rp
         SET zip_id = rp_parent.zip_id, city_id = rp_parent.city_id
         FROM (
-            SELECT id, zip_id, city_id 
+            SELECT id, zip_id, city_id
             FROM res_partner) rp_parent
         WHERE rp.parent_id = rp_parent.id;
         """,

--- a/partner_compassion/migrations/14.0.1.0.2/post-migrate.py
+++ b/partner_compassion/migrations/14.0.1.0.2/post-migrate.py
@@ -22,7 +22,7 @@ def migrate(env, version):
         UPDATE res_partner rp 
         SET zip_id=rcz.id 
         FROM res_city_zip rcz
-        WHERE rp.city_id = res_city_zip.city_id 
+        WHERE rp.city_id = rcz.city_id 
             AND rp.zip = rcz.name
             AND rp.zip_id IS NULL
             AND rp.parent_id IS NULL;
@@ -34,7 +34,7 @@ def migrate(env, version):
         UPDATE res_partner rp 
         SET zip_id = rp_parent.zip_id, city_id = rp_parent.city_id
         FROM (
-            SELECT zip_id, city_id 
+            SELECT id, zip_id, city_id 
             FROM res_partner) rp_parent
         WHERE rp.parent_id = rp_parent.id;
         """,

--- a/partner_compassion/views/partner_compassion_view.xml
+++ b/partner_compassion/views/partner_compassion_view.xml
@@ -577,7 +577,9 @@
         <field name="inherit_id" ref="base.view_partner_form" />
         <field name="arch" type="xml">
             <field name="zip_id" position="attributes">
-                <attribute name="attrs">{'required': [('city', '!=', False), ('state_id', '!=', False), ('zip', '!=', False)], 'readonly': [('type', '=', 'contact'),('parent_id', '!=', False)]}</attribute>
+                <attribute
+          name="attrs"
+        >{'required': [('city', '!=', False), ('state_id', '!=', False), ('zip', '!=', False)], 'readonly': [('type', '=', 'contact'),('parent_id', '!=', False)]}</attribute>
             </field>
         </field>
     </record>

--- a/partner_compassion/views/partner_compassion_view.xml
+++ b/partner_compassion/views/partner_compassion_view.xml
@@ -570,6 +570,18 @@
         </field>
     </record>
 
+    <!-- Make zip_id required if related fields are set -->
+    <record model="ir.ui.view" id="view_partner_form_inherit">
+        <field name="name">res.partner.form.inherit</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_partner_form" />
+        <field name="arch" type="xml">
+            <field name="zip_id" position="attributes">
+                <attribute name="attrs">{'required': [('city', '!=', False), ('state_id', '!=', False), ('zip', '!=', False)], 'readonly': [('type', '=', 'contact'),('parent_id', '!=', False)]}</attribute>
+            </field>
+        </field>
+    </record>
+
     <menuitem
     id="sponsorship_compassion.open_customers"
     action="action_partner_supporter_form"


### PR DESCRIPTION
# Description
When editing a contact, there was a weird bug where we could not set the related company (the `parent_id`) for that contact. It would result in an exception.

# Technical Aspects
The issue seems to be that when we set the parent_id, the res_partner inherits the parent's address, but in the case where the city_id was null, an invalid ORM call was made resulting in an exception. 

Following fixes were made : 
- Added a migration that will fix the `city_id` and `zip_id` for existing data
- Improved the contact form a bit by making the `zip_id` field required when related data is set
- Added a label next to the `parent_id` input so that users know what it is (for some reason there is no automatic labelling for that field) in the [follow-up PR](https://github.com/CompassionCH/compassion-modules/pull/1959/files)