### PR TITLE
T1737 - Constraint Error When Creating/Editing CRM Opportunities Without Customer Email

### DIFF
--- a/mass_mailing_switzerland/__init__.py
+++ b/mass_mailing_switzerland/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/mass_mailing_switzerland/__manifest__.py
+++ b/mass_mailing_switzerland/__manifest__.py
@@ -1,0 +1,18 @@
+# Copyright 2024 Compassion CH (http://www.compassion.ch)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+{
+    "name": "Compassion CH Mass Mailing",
+    "summary": "Mass mailing for Compassion CH",
+    "author": "Compassion Switzerland",
+    "website": "https://github.com/CompassionCH/compassion-switzerland",
+    "license": "AGPL-3",
+    "category": "Marketing",
+    "version": "14.0.1.0.0",
+    "depends": [
+        "mass_mailing_partner",
+    ],
+    "data": [],
+    "demo": [],
+    "installable": True,
+    "auto_install": True,
+}

--- a/mass_mailing_switzerland/models/__init__.py
+++ b/mass_mailing_switzerland/models/__init__.py
@@ -1,0 +1,1 @@
+from . import res_partner

--- a/mass_mailing_switzerland/models/res_partner.py
+++ b/mass_mailing_switzerland/models/res_partner.py
@@ -1,0 +1,22 @@
+##############################################################################
+#
+#    Copyright (C) 2015 Compassion CH (http://www.compassion.ch)
+#    Releasing children from poverty in Jesus' name
+#    @author: Emanuel Cino <ecino@compassion.ch>
+#
+#    The licence is in the file __manifest__.py
+#
+##############################################################################
+
+from odoo import models
+
+
+class Partner(models.Model):
+    _inherit = "res.partner"
+
+    def write(self, vals):
+        if "email" in vals:
+            for partner in self:
+                if not vals["email"] and partner.sudo().mass_mailing_contact_ids:
+                    partner.sudo().mass_mailing_contact_ids.unlink()
+        return super(Partner, self).write(vals)

--- a/setup/mass_mailing_switzerland/odoo/addons/mass_mailing_switzerland
+++ b/setup/mass_mailing_switzerland/odoo/addons/mass_mailing_switzerland
@@ -1,0 +1,1 @@
+../../../../mass_mailing_switzerland

--- a/setup/mass_mailing_switzerland/setup.py
+++ b/setup/mass_mailing_switzerland/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
# Context

When the church reps wants to create or edit an opportunity (crm.lead) and make it with a customer but without an email, there is a constraint error.

Sometimes, they are working with customers that has no emails, they should be able to pass against this email constraint.

# Analysis

The error occurs because the contact is part of an email distribution list. As a result, removing the contact’s email address leads to an error. This is a standard error designed to prevent cascading failures when sending emails through the distribution list.

# Proposed solutions

There are two possible solutions:

1. Keep this protection in place to ensure no errors occur when using distribution lists (current solution).
2. Remove the contact from the distribution list.

In my opinion, we should implement the second solution. If an email address is removed from a contact, it is because it is no longer in use or relevant. Therefore, not sending emails to this address for marketing campaigns should not cause any issues.