### PR TITLE
T1792 - Desynchronize crm.lead and res_partner email.

### DIFF
--- a/mass_mailing_switzerland/models/__init__.py
+++ b/mass_mailing_switzerland/models/__init__.py
@@ -1,1 +1,1 @@
-from . import res_partner
+from . import crm_lead

--- a/mass_mailing_switzerland/models/crm_lead.py
+++ b/mass_mailing_switzerland/models/crm_lead.py
@@ -8,10 +8,18 @@
 #
 ##############################################################################
 
-from odoo import models
+from odoo import api, models
 
 class Lead(models.Model):
     _inherit = "crm.lead"
 
     def _inverse_email_from(self):
         return
+
+    @api.depends('partner_id.email')
+    def _compute_email_from(self):
+        return
+
+    @api.onchange('partner_id')
+    def onchange_partner_id(self):
+        self.email_from = self.partner_id.email

--- a/mass_mailing_switzerland/models/crm_lead.py
+++ b/mass_mailing_switzerland/models/crm_lead.py
@@ -10,7 +10,7 @@
 
 from odoo import models
 
-class Partner(models.Model):
+class Lead(models.Model):
     _inherit = "crm.lead"
 
     def _inverse_email_from(self):

--- a/mass_mailing_switzerland/models/crm_lead.py
+++ b/mass_mailing_switzerland/models/crm_lead.py
@@ -10,13 +10,8 @@
 
 from odoo import models
 
-
 class Partner(models.Model):
-    _inherit = "res.partner"
+    _inherit = "crm.lead"
 
-    def write(self, vals):
-        if "email" in vals:
-            for partner in self:
-                if not vals["email"] and partner.sudo().mass_mailing_contact_ids:
-                    partner.sudo().mass_mailing_contact_ids.unlink()
-        return super(Partner, self).write(vals)
+    def _inverse_email_from(self):
+        return

--- a/mass_mailing_switzerland/models/crm_lead.py
+++ b/mass_mailing_switzerland/models/crm_lead.py
@@ -10,16 +10,17 @@
 
 from odoo import api, models
 
+
 class Lead(models.Model):
     _inherit = "crm.lead"
 
     def _inverse_email_from(self):
         return
 
-    @api.depends('partner_id.email')
+    @api.depends("partner_id.email")
     def _compute_email_from(self):
         return
 
-    @api.onchange('partner_id')
+    @api.onchange("partner_id")
     def onchange_partner_id(self):
         self.email_from = self.partner_id.email


### PR DESCRIPTION
By default, the behavior of the "email" field in the "crm.lead" model is to sync with the partner's email. This synchronization causes issues and generates errors because the email address is tied to a mailing contact. A solution that addresses tasks T1792, T1552, and T1737 is to initially prefill this field with the selected partner’s email but then allow the email to become independent of the partner. This makes sense in cases like when a church has a general contact email, but for a specific event, the contact is made using a different email address.

However, this solution has the drawback of no longer allowing a simultaneous update of all "crm.lead" records for a partner if the contact email changes.