### PR TITLE
T1693 - Signature not translated when first generated from CRON

### DIFF
--- a/partner_communication_switzerland/models/res_users.py
+++ b/partner_communication_switzerland/models/res_users.py
@@ -76,30 +76,13 @@ class ResUsers(models.Model):
             for user in self:
                 employee = user.employee_ids[:1].with_context(bin_size=False)
 
-                # welp, this seems to work...
-                translated_title = self.env["ir.translation"].search([('src', '=', employee.job_title), ('lang', '=', lang), ('res_id', '=', employee.id)]).value
-
-                #employee.ensure_one()
-                #employee.refresh()
-                #employee.clear_caches()
-                #employee.recompute(fnames=['job_title'])
-                #self.env['hr.employee'].recompute(fnames=['job_title'], records=employee)
-                #self.env['hr.employee'].invalidate_cache(['job_title'], ids=[employee.id])
-                #self.env['hr.employee'].flush(fnames=['job_title'],  records=employee)
-
-                _logger.info(f"JOB TITLE EMPLOYEE ------------> {employee.job_title}")
-                _logger.info(f"I DONT KNOW BRO... ------------> {_(employee.job_title)}")
-                _logger.info(f"WHY DO I EVEN DO TRY... ------------> {translated_title}")
-                # _logger.info(f"JOB TITLE FROM ID ------------> {employee.job_id.name}") IS NEVER TRANSLATED, THE TEXT IS ALWAYS "SDS Worker"
-                _logger.info(f"COMPANY NAME EMPLOYEE ------------> {employee.company_id.address_name}")
-                _logger.info(f"COMPANY NAME USER ------------> {user.company_id.address_name}")
-
-                _logger.info(f"IDDDDDDDDDD ------------> {id(employee)}")
-
-
-                # _logger.info(f"TOTO ------------> {user.job_title}") NOPE
-                # _logger.info(f"TATA ------------> {user.employee_id.job_title}") NOPE
-                # _logger.info(f"TITI ------------> {user.employee_id.job_id.name}") NOPE
+                # Workaround that manually gets translation from the table,
+                # see T1693 and related PR for more information.
+                job_title = self.env["ir.translation"]._get_source(None,
+                                                                   ("model",),
+                                                                   lang,
+                                                                   employee.job_title,
+                                                                   employee.id)
 
                 employee_image_url = f"{base_url}/employee/image/{employee.id}"
 
@@ -111,7 +94,7 @@ class ResUsers(models.Model):
                     "lang": lang,
                     "lang_short": lang[:2],
                     "team": _("and the team of Compassion") if user.firstname else "",
-                    "job_title": employee.job_title or "",
+                    "job_title": job_title or "",
                     "office_hours": _("mo-thu: 9am-2pm"),
                     "company_name": user.company_id.address_name,
                     "phone_link": phone_link.get(lang),

--- a/partner_communication_switzerland/models/res_users.py
+++ b/partner_communication_switzerland/models/res_users.py
@@ -71,11 +71,9 @@ class ResUsers(models.Model):
 
                 # Workaround that manually gets translation from the table,
                 # see T1693 and related PR for more information.
-                job_title = self.env["ir.translation"]._get_source(None,
-                                                                   ("model",),
-                                                                   lang,
-                                                                   employee.job_title,
-                                                                   employee.id)
+                job_title = self.env["ir.translation"]._get_source(
+                    None, ("model",), lang, employee.job_title, employee.id
+                )
 
                 employee_image_url = f"{base_url}/employee/image/{employee.id}"
 

--- a/partner_communication_switzerland/models/res_users.py
+++ b/partner_communication_switzerland/models/res_users.py
@@ -68,6 +68,8 @@ class ResUsers(models.Model):
 
             for user in self:
                 employee = user.employee_ids[:1].with_context(bin_size=False)
+                _logger.info(f"JOB TITLE ------------> {employee.job_title}")
+                _logger.info(f"JOB TITLE OTHERRRR ------------> {user.employee_ids[:1].job_title}")
                 employee_image_url = f"{base_url}/employee/image/{employee.id}"
 
                 values = {

--- a/partner_communication_switzerland/models/res_users.py
+++ b/partner_communication_switzerland/models/res_users.py
@@ -67,10 +67,18 @@ class ResUsers(models.Model):
             base_url = self.env["ir.config_parameter"].sudo().get_param("web.base.url")
 
             for user in self:
+                user.recompute()
+
                 employee = user.employee_ids[:1].with_context(bin_size=False)
-                _logger.info(f"JOB TITLE ------------> {employee.job_title}")
-                _logger.info(f"JOB TITLE OTHERRRR ------------> {user.employee_ids[:1].job_title}")
+
+                _logger.info(f"JOB TITLE EMPLOYEE ------------> {employee.job_title}")
+                _logger.info(f"JOB TITLE EMPLOYEE ------------> {user.employee_id.job_title}")
+                _logger.info(f"COMPANY NAME EMPLOYEE ------------> {employee.company_id.address_name}")
+                _logger.info(f"COMPANY NAME USER ------------> {user.company_id.address_name}")
+                _logger.info(f"COMPANY NAME USER ------------> {user.job_title}")
                 employee_image_url = f"{base_url}/employee/image/{employee.id}"
+
+
 
                 values = {
                     "name": f"{user.preferred_name} {user.lastname}"

--- a/partner_communication_switzerland/models/res_users.py
+++ b/partner_communication_switzerland/models/res_users.py
@@ -2,12 +2,19 @@
 
 import logging
 
+import time
+from inspect import trace
+
 from pyquery import PyQuery
 
 from odoo import _, fields, models
 from odoo.tools import file_open
 
 from odoo.addons.auth_signup.models.res_partner import now
+
+
+import traceback
+
 
 _logger = logging.getLogger(__name__)
 
@@ -67,18 +74,34 @@ class ResUsers(models.Model):
             base_url = self.env["ir.config_parameter"].sudo().get_param("web.base.url")
 
             for user in self:
-                user.recompute()
-
                 employee = user.employee_ids[:1].with_context(bin_size=False)
 
+                # welp, this seems to work...
+                translated_title = self.env["ir.translation"].search([('src', '=', employee.job_title), ('lang', '=', lang), ('res_id', '=', employee.id)]).value
+
+                #employee.ensure_one()
+                #employee.refresh()
+                #employee.clear_caches()
+                #employee.recompute(fnames=['job_title'])
+                #self.env['hr.employee'].recompute(fnames=['job_title'], records=employee)
+                #self.env['hr.employee'].invalidate_cache(['job_title'], ids=[employee.id])
+                #self.env['hr.employee'].flush(fnames=['job_title'],  records=employee)
+
                 _logger.info(f"JOB TITLE EMPLOYEE ------------> {employee.job_title}")
-                _logger.info(f"JOB TITLE EMPLOYEE ------------> {user.employee_id.job_title}")
+                _logger.info(f"I DONT KNOW BRO... ------------> {_(employee.job_title)}")
+                _logger.info(f"WHY DO I EVEN DO TRY... ------------> {translated_title}")
+                # _logger.info(f"JOB TITLE FROM ID ------------> {employee.job_id.name}") IS NEVER TRANSLATED, THE TEXT IS ALWAYS "SDS Worker"
                 _logger.info(f"COMPANY NAME EMPLOYEE ------------> {employee.company_id.address_name}")
                 _logger.info(f"COMPANY NAME USER ------------> {user.company_id.address_name}")
-                _logger.info(f"COMPANY NAME USER ------------> {user.job_title}")
+
+                _logger.info(f"IDDDDDDDDDD ------------> {id(employee)}")
+
+
+                # _logger.info(f"TOTO ------------> {user.job_title}") NOPE
+                # _logger.info(f"TATA ------------> {user.employee_id.job_title}") NOPE
+                # _logger.info(f"TITI ------------> {user.employee_id.job_id.name}") NOPE
+
                 employee_image_url = f"{base_url}/employee/image/{employee.id}"
-
-
 
                 values = {
                     "name": f"{user.preferred_name} {user.lastname}"

--- a/partner_communication_switzerland/models/res_users.py
+++ b/partner_communication_switzerland/models/res_users.py
@@ -71,7 +71,7 @@ class ResUsers(models.Model):
 
                 # Workaround that manually gets translation from the table,
                 # see T1693 and related PR for more information.
-                job_title = self.env["ir.translation"]._get_source(
+                employee_job_title = self.env["ir.translation"]._get_source(
                     None, ("model",), lang, employee.job_title, employee.id
                 )
 
@@ -85,7 +85,7 @@ class ResUsers(models.Model):
                     "lang": lang,
                     "lang_short": lang[:2],
                     "team": _("and the team of Compassion") if user.firstname else "",
-                    "job_title": job_title or "",
+                    "job_title": employee_job_title or "",
                     "office_hours": _("mo-thu: 9am-2pm"),
                     "company_name": user.company_id.address_name,
                     "phone_link": phone_link.get(lang),

--- a/partner_communication_switzerland/models/res_users.py
+++ b/partner_communication_switzerland/models/res_users.py
@@ -2,19 +2,12 @@
 
 import logging
 
-import time
-from inspect import trace
-
 from pyquery import PyQuery
 
 from odoo import _, fields, models
 from odoo.tools import file_open
 
 from odoo.addons.auth_signup.models.res_partner import now
-
-
-import traceback
-
 
 _logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
# Description
There was a bug where when a correspondence is generated through a CRON, the correspondence would be translated except for the `job_title` in the signature. Simply refreshing the correspondence would then translate it as well.

# Technical Aspects
For some reason when `employee,job_title` is called from the CRON that generates the correspondence the field is not translated (even if in the field defition it is specified as `translate=True`). But if we then refresh the correspondece which triggers the compute of the signature, the `employee,job_title` is translated correctly.

The only solution we found was a work-around where we manually fetch the translation from the `ir_translations` table.

# Better Solution
A better solution would probably be to remove the override of the `job_title` field in `hr_switzerland/models/hm_employee.py`. We would then also need to re-translate every job title since the source now points to the result of the related field which is `employee_id.job_id.name` (found in `hr/models/res_users.py`).