### PR TITLE
T1799 - Fix sponsorship onboarding form

### DIFF
--- a/partner_communication_switzerland/data/form_data.xml
+++ b/partner_communication_switzerland/data/form_data.xml
@@ -21,6 +21,7 @@
         'inform_me_for_next_zoom',
         'optional_message',
         'zoom_session_id',
+        'state',
         ]"
     />
     </function>

--- a/partner_communication_switzerland/models/res_partner_zoom_attendee.py
+++ b/partner_communication_switzerland/models/res_partner_zoom_attendee.py
@@ -86,12 +86,18 @@ class ZoomAttendee(models.Model):
 
         for vals in vals_list:
             existing_attendee = self.search(
-                [('partner_id', '=', vals.get('partner_id')),
-                 ('zoom_session_id', '=', vals.get('zoom_session_id'))])
+                [
+                    ("partner_id", "=", vals.get("partner_id")),
+                    ("zoom_session_id", "=", vals.get("zoom_session_id")),
+                ]
+            )
             if existing_attendee:
                 vals_list_to_create.remove(vals)
-                filtered_vals = {k: v for k, v in vals.items() 
-                                 if k not in ['partner_id', 'zoom_session_id']}
+                filtered_vals = {
+                    k: v
+                    for k, v in vals.items()
+                    if k not in ["partner_id", "zoom_session_id"]
+                }
                 existing_attendee.update(filtered_vals)
                 res.append(existing_attendee)
 
@@ -105,13 +111,17 @@ class ZoomAttendee(models.Model):
         return res
 
     def test_dumb_stuff(self):
-        self.env['res.partner.zoom.attendee'].create([{
-            'partner_id': 43327,
-            'zoom_session_id': 44,
-            'state': 'confirmed',
-            'partner_firstname': 'Praz',
-            'partner_lastname': 'Nicolas'
-        }])
+        self.env["res.partner.zoom.attendee"].create(
+            [
+                {
+                    "partner_id": 43327,
+                    "zoom_session_id": 44,
+                    "state": "confirmed",
+                    "partner_firstname": "Praz",
+                    "partner_lastname": "Nicolas",
+                }
+            ]
+        )
 
     def inform_about_next_session(self):
         for attendee in self:

--- a/partner_communication_switzerland/models/res_partner_zoom_attendee.py
+++ b/partner_communication_switzerland/models/res_partner_zoom_attendee.py
@@ -93,15 +93,12 @@ class ZoomAttendee(models.Model):
             )
             if existing_attendee:
                 vals_list_to_create.remove(vals)
-                filtered_vals = {
-                    k: v
-                    for k, v in vals.items()
-                    if k not in ["partner_id", "zoom_session_id"]
-                }
-                existing_attendee.update(filtered_vals)
-                res.append(existing_attendee)
+                del vals["partner_id"]
+                del vals["zoom_session"]
+                existing_attendee.write(vals)
+                res += existing_attendee
 
-        res.append(super().create(vals_list_to_create))
+        res += super().create(vals_list_to_create)
 
         for attendee in res:
             if attendee.inform_me_for_next_zoom:

--- a/partner_communication_switzerland/models/res_partner_zoom_attendee.py
+++ b/partner_communication_switzerland/models/res_partner_zoom_attendee.py
@@ -82,19 +82,19 @@ class ZoomAttendee(models.Model):
     @api.model_create_multi
     def create(self, vals_list):
         res = []
-        filtered_vals_lists = vals_list.copy()
+        vals_list_to_create = vals_list.copy()
 
         for vals in vals_list:
             existing_attendee = self.search(
                 [('partner_id', '=', vals.get('partner_id')),
                  ('zoom_session_id', '=', vals.get('zoom_session_id'))])
             if existing_attendee:
-                filtered_vals_lists.remove(vals)
-                toto = {k: v for k, v in vals.items() if k not in ['partner_id', 'zoom_session_id']}
-                existing_attendee.update(toto)
+                vals_list_to_create.remove(vals)
+                filtered_vals = {k: v for k, v in vals.items() if k not in ['partner_id', 'zoom_session_id']}
+                existing_attendee.update(filtered_vals)
                 res.append(existing_attendee)
 
-        res.append(super().create(filtered_vals_lists))
+        res.append(super().create(vals_list_to_create))
 
         for attendee in res:
             if attendee.inform_me_for_next_zoom:

--- a/partner_communication_switzerland/models/res_partner_zoom_attendee.py
+++ b/partner_communication_switzerland/models/res_partner_zoom_attendee.py
@@ -116,9 +116,16 @@ class ZoomAttendee(models.Model):
                 {
                     "partner_id": 43327,
                     "zoom_session_id": 44,
-                    "state": "confirmed",
+                    "state": "declined",
                     "partner_firstname": "Praz",
                     "partner_lastname": "Nicolas",
+                },
+                {
+                    "partner_id": 43190,
+                    "zoom_session_id": 44,
+                    "state": "invited",
+                    "partner_firstname": "Diego",
+                    "partner_lastname": "Cruz Pastor",
                 }
             ]
         )

--- a/partner_communication_switzerland/models/res_partner_zoom_attendee.py
+++ b/partner_communication_switzerland/models/res_partner_zoom_attendee.py
@@ -110,26 +110,6 @@ class ZoomAttendee(models.Model):
                 attendee.notify_user()
         return res
 
-    def test_dumb_stuff(self):
-        self.env["res.partner.zoom.attendee"].create(
-            [
-                {
-                    "partner_id": 43327,
-                    "zoom_session_id": 44,
-                    "state": "declined",
-                    "partner_firstname": "Praz",
-                    "partner_lastname": "Nicolas",
-                },
-                {
-                    "partner_id": 43190,
-                    "zoom_session_id": 44,
-                    "state": "invited",
-                    "partner_firstname": "Diego",
-                    "partner_lastname": "Cruz Pastor",
-                }
-            ]
-        )
-
     def inform_about_next_session(self):
         for attendee in self:
             attendee.state = "declined"

--- a/partner_communication_switzerland/models/res_partner_zoom_attendee.py
+++ b/partner_communication_switzerland/models/res_partner_zoom_attendee.py
@@ -90,7 +90,8 @@ class ZoomAttendee(models.Model):
                  ('zoom_session_id', '=', vals.get('zoom_session_id'))])
             if existing_attendee:
                 vals_list_to_create.remove(vals)
-                filtered_vals = {k: v for k, v in vals.items() if k not in ['partner_id', 'zoom_session_id']}
+                filtered_vals = {k: v for k, v in vals.items() 
+                                 if k not in ['partner_id', 'zoom_session_id']}
                 existing_attendee.update(filtered_vals)
                 res.append(existing_attendee)
 

--- a/partner_communication_switzerland/models/res_partner_zoom_attendee.py
+++ b/partner_communication_switzerland/models/res_partner_zoom_attendee.py
@@ -81,7 +81,7 @@ class ZoomAttendee(models.Model):
 
     @api.model_create_multi
     def create(self, vals_list):
-        res = []
+        res = self
         vals_list_to_create = vals_list.copy()
 
         for vals in vals_list:
@@ -94,7 +94,7 @@ class ZoomAttendee(models.Model):
             if existing_attendee:
                 vals_list_to_create.remove(vals)
                 del vals["partner_id"]
-                del vals["zoom_session"]
+                del vals["zoom_session_id"]
                 existing_attendee.write(vals)
                 res += existing_attendee
 

--- a/partner_communication_switzerland/models/res_partner_zoom_attendee.py
+++ b/partner_communication_switzerland/models/res_partner_zoom_attendee.py
@@ -81,8 +81,8 @@ class ZoomAttendee(models.Model):
 
     @api.model_create_multi
     def create(self, vals_list):
-        updated_models = []
-        filtered_vals_lists = vals_list
+        res = []
+        filtered_vals_lists = vals_list.copy()
 
         for vals in vals_list:
             existing_attendee = self.search(
@@ -92,11 +92,9 @@ class ZoomAttendee(models.Model):
                 filtered_vals_lists.remove(vals)
                 toto = {k: v for k, v in vals.items() if k not in ['partner_id', 'zoom_session_id']}
                 existing_attendee.update(toto)
-                updated_models.append(existing_attendee)
+                res.append(existing_attendee)
 
-        created_models = super().create(filtered_vals_lists)
-
-        res = updated_models.append(created_models)
+        res.append(super().create(filtered_vals_lists))
 
         for attendee in res:
             if attendee.inform_me_for_next_zoom:

--- a/partner_communication_switzerland/templates/zoom_registration_form.xml
+++ b/partner_communication_switzerland/templates/zoom_registration_form.xml
@@ -287,7 +287,7 @@
                 </div>
               </div>
             </div>
-              <div
+            <div
                 class="form-group s_website_form_field_hidden col-12    "
                 data-type="boolean"
                 data-name="Field"
@@ -300,6 +300,23 @@
                       class="s_website_form_input"
                       name="zoom_session_id"
                       id="ow6ngqr314yssdf"
+                    />
+                </div>
+              </div>
+            </div>
+            <div
+                class="form-group s_website_form_field_hidden col-12    "
+                data-type="char"
+                data-name="Field"
+              >
+              <div class="row s_col_no_resize s_col_no_bgcolor">
+                <div class="col-sm">
+                  <input
+                      type="text"
+                      value="confirmed"
+                      class="s_website_form_input"
+                      name="state"
+                      id="toto"
                     />
                 </div>
               </div>

--- a/partner_communication_switzerland/templates/zoom_registration_form.xml
+++ b/partner_communication_switzerland/templates/zoom_registration_form.xml
@@ -316,7 +316,7 @@
                       value="confirmed"
                       class="s_website_form_input"
                       name="state"
-                      id="toto"
+                      id="default_state"
                     />
                 </div>
               </div>


### PR DESCRIPTION
# Description
New sponsors are invited to a visio conference through a communication with a link to a form where they can register, which will add a new `partner_zoom_attendee`. However if the participant is already invited and then clicks on the form an sql exception will be raised because the participant already exists.

# Technical Aspects
Two fixes have been made : 
* The registration form will now set the parcipant in the state `confirmed` if they click on the "Register" button
* When we create a new `partner_zoom_attendee`, if he already exists we simply update the information