### PR TITLE
T1823 - Biennial signature wrong when printing multiple communications

### DIFF
--- a/partner_communication_switzerland/models/res_users.py
+++ b/partner_communication_switzerland/models/res_users.py
@@ -4,7 +4,7 @@ import logging
 
 from pyquery import PyQuery
 
-from odoo import _, fields, models, api
+from odoo import _, api, fields, models
 from odoo.tools import file_open
 
 from odoo.addons.auth_signup.models.res_partner import now
@@ -40,7 +40,7 @@ class ResUsers(models.Model):
                     }
                 )
 
-    @api.depends_context('lang')
+    @api.depends_context("lang")
     def _compute_signature(self):
         with file_open(
             "partner_communication_switzerland/static/html/signature.html"

--- a/partner_communication_switzerland/models/res_users.py
+++ b/partner_communication_switzerland/models/res_users.py
@@ -4,7 +4,7 @@ import logging
 
 from pyquery import PyQuery
 
-from odoo import _, fields, models
+from odoo import _, fields, models, api
 from odoo.tools import file_open
 
 from odoo.addons.auth_signup.models.res_partner import now
@@ -40,6 +40,7 @@ class ResUsers(models.Model):
                     }
                 )
 
+    @api.depends_context('lang')
     def _compute_signature(self):
         with file_open(
             "partner_communication_switzerland/static/html/signature.html"


### PR DESCRIPTION
# Description
When refreshing or printing multiple communications from the same user but of different language, all the signatures are printed with the same language as the first communication. So if we were to print french and german communications but the first was in french, all signatures would be in french.

# Technical Aspects
It seems that the signature of the user is re-computed only when the user changes, so even if the language changes, it is not recomputed.
The fix is pretty simple, we added a decorator `@api.depends_context('lang')` on the compute method so that signature is recomputed when the `lang` changes.