### PR TITLE
T1799 - Fix zoom invite Part 2 (1/2)

### DIFF
--- a/partner_communication_switzerland/controllers/zoom_registration.py
+++ b/partner_communication_switzerland/controllers/zoom_registration.py
@@ -33,19 +33,16 @@ class ZoomRegistration(Controller):
     def zoom_registration(self, session=None, **kwargs):
         if session is None:
             # Allow to register in the current zoom session for 15 minutes after start
-            start = datetime.now() - timedelta(minutes=15)
+            start = datetime.now() - timedelta(days=15)
             session = request.env["res.partner.zoom.session"].get_next_session(start)
         if not session.website_published:
             raise Unauthorized()
-        participant = request.env["res.partner.zoom.attendee"]
+        partner = request.env["res.partner"]
         if request.env.user and request.env.user != request.env.ref("base.public_user"):
             partner = request.env.user.partner_id
             kwargs["partner_id"] = partner.id
-            participant = session.participant_ids.filtered(
-                lambda p: p.partner_id == partner
-            )
         kwargs["zoom_session_id"] = session.id
         return request.render(
             "partner_communication_switzerland.zoom_registration_template",
-            {"session": session, "main_object": participant},
+            {"session": session, "partner": partner},
         )

--- a/partner_communication_switzerland/controllers/zoom_registration.py
+++ b/partner_communication_switzerland/controllers/zoom_registration.py
@@ -33,7 +33,7 @@ class ZoomRegistration(Controller):
     def zoom_registration(self, session=None, **kwargs):
         if session is None:
             # Allow to register in the current zoom session for 15 minutes after start
-            start = datetime.now() - timedelta(days=15)
+            start = datetime.now() - timedelta(minutes=15)
             session = request.env["res.partner.zoom.session"].get_next_session(start)
         if not session.website_published:
             raise Unauthorized()

--- a/partner_communication_switzerland/data/form_data.xml
+++ b/partner_communication_switzerland/data/form_data.xml
@@ -21,6 +21,7 @@
         'inform_me_for_next_zoom',
         'optional_message',
         'zoom_session_id',
+        'partner_id',
         'state',
         ]"
     />

--- a/partner_communication_switzerland/models/res_partner_zoom_attendee.py
+++ b/partner_communication_switzerland/models/res_partner_zoom_attendee.py
@@ -101,7 +101,8 @@ class ZoomAttendee(models.Model):
 
             else:
                 partner_vals = self._convert_vals_for_res_partner(vals)
-                partner_id = self.env["res.partner.match"].match_values_to_partner(partner_vals, match_update=False, match_create=False).id
+                partner_id = self.env["res.partner.match"].match_values_to_partner(
+                    partner_vals, match_update=False, match_create=False).id
 
                 existing_attendee = self.search(
                     [

--- a/partner_communication_switzerland/models/res_partner_zoom_attendee.py
+++ b/partner_communication_switzerland/models/res_partner_zoom_attendee.py
@@ -101,8 +101,13 @@ class ZoomAttendee(models.Model):
 
             else:
                 partner_vals = self._convert_vals_for_res_partner(vals)
-                partner_id = self.env["res.partner.match"].match_values_to_partner(
-                    partner_vals, match_update=False, match_create=False).id
+                partner_id = (
+                    self.env["res.partner.match"]
+                    .match_values_to_partner(
+                        partner_vals, match_update=False, match_create=False
+                    )
+                    .id
+                )
 
                 existing_attendee = self.search(
                     [

--- a/partner_communication_switzerland/models/res_partner_zoom_attendee.py
+++ b/partner_communication_switzerland/models/res_partner_zoom_attendee.py
@@ -85,18 +85,38 @@ class ZoomAttendee(models.Model):
         vals_list_to_create = vals_list.copy()
 
         for vals in vals_list:
-            existing_attendee = self.search(
-                [
-                    ("partner_id", "=", vals.get("partner_id")),
-                    ("zoom_session_id", "=", vals.get("zoom_session_id")),
-                ]
-            )
-            if existing_attendee:
-                vals_list_to_create.remove(vals)
-                del vals["partner_id"]
-                del vals["zoom_session_id"]
-                existing_attendee.write(vals)
-                res += existing_attendee
+            if vals.get("partner_id"):
+                existing_attendee = self.search(
+                    [
+                        ("partner_id", "=", vals.get("partner_id")),
+                        ("zoom_session_id", "=", vals.get("zoom_session_id")),
+                    ]
+                )
+                if existing_attendee:
+                    vals_list_to_create.remove(vals)
+                    del vals["partner_id"]
+                    del vals["zoom_session_id"]
+                    existing_attendee.write(vals)
+                    res += existing_attendee
+
+            else:
+                partner_vals = self._convert_vals_for_res_partner(vals)
+                partner_id = self.env["res.partner.match"].match_values_to_partner(partner_vals, match_update=False, match_create=False).id
+
+                existing_attendee = self.search(
+                    [
+                        ("partner_id", "=", partner_id),
+                        ("zoom_session_id", "=", vals.get("zoom_session_id")),
+                    ]
+                )
+                if existing_attendee:
+                    vals_list_to_create.remove(vals)
+                    del vals["partner_firstname"]
+                    del vals["partner_lastname"]
+                    del vals["partner_email"]
+                    del vals["zoom_session_id"]
+                    existing_attendee.write(vals)
+                    res += existing_attendee
 
         res += super().create(vals_list_to_create)
 

--- a/partner_communication_switzerland/templates/zoom_registration_form.xml
+++ b/partner_communication_switzerland/templates/zoom_registration_form.xml
@@ -120,6 +120,7 @@
                       type="text"
                       class="form-control s_website_form_input"
                       name="partner_firstname"
+                      t-att-value="partner.firstname"
                       required="true"
                       id="otfjqdxg28m9"
                     />
@@ -149,6 +150,7 @@
                       type="text"
                       class="form-control s_website_form_input"
                       name="partner_lastname"
+                      t-att-value="partner.lastname"
                       required="true"
                       id="ozoz9llszzse"
                     />
@@ -174,6 +176,7 @@
                       type="text"
                       class="form-control s_website_form_input"
                       name="partner_email"
+                      t-att-value="partner.email"
                       required="true"
                       id="o44vytmw5eep"
                     />
@@ -300,6 +303,23 @@
                       class="s_website_form_input"
                       name="zoom_session_id"
                       id="ow6ngqr314yssdf"
+                    />
+                </div>
+              </div>
+            </div>
+              <div
+                class="form-group s_website_form_field_hidden col-12    "
+                data-type="boolean"
+                data-name="Field"
+              >
+              <div class="row s_col_no_resize s_col_no_bgcolor">
+                <div class="col-sm">
+                  <input
+                      type="text"
+                      t-att-value="partner.id"
+                      class="s_website_form_input"
+                      name="partner_id"
+                      id="partner_id"
                     />
                 </div>
               </div>

--- a/partner_communication_switzerland/templates/zoom_registration_form.xml
+++ b/partner_communication_switzerland/templates/zoom_registration_form.xml
@@ -118,9 +118,9 @@
                 <div class="col-sm">
                   <input
                       type="text"
+                      t-att-value="partner.firstname"
                       class="form-control s_website_form_input"
                       name="partner_firstname"
-                      t-att-value="partner.firstname"
                       required="true"
                       id="otfjqdxg28m9"
                     />
@@ -148,9 +148,9 @@
                 <div class="col-sm">
                   <input
                       type="text"
+                      t-att-value="partner.lastname"
                       class="form-control s_website_form_input"
                       name="partner_lastname"
-                      t-att-value="partner.lastname"
                       required="true"
                       id="ozoz9llszzse"
                     />
@@ -174,9 +174,9 @@
                 <div class="col-sm">
                   <input
                       type="text"
+                      t-att-value="partner.email"
                       class="form-control s_website_form_input"
                       name="partner_email"
-                      t-att-value="partner.email"
                       required="true"
                       id="o44vytmw5eep"
                     />
@@ -199,6 +199,7 @@
                 <div class="col-sm">
                   <input
                       type="text"
+                      t-att-value="partner.phone"
                       class="form-control s_website_form_input"
                       name="partner_phone"
                       id="ocd0qhy3mm5"
@@ -307,7 +308,7 @@
                 </div>
               </div>
             </div>
-              <div
+            <div
                 class="form-group s_website_form_field_hidden col-12    "
                 data-type="boolean"
                 data-name="Field"


### PR DESCRIPTION
# Description
Seems that the previous [PR](https://github.com/CompassionCH/compassion-switzerland/pull/1656) did not fix the bug. The issue is that the user can also access the registration even if he is not logged in, so we need to handle that case as well.

# Technical Aspects
We now handle two cases when registering a partner to a zoom meeting:
* The user is logged in, so we pass the `partner_id` that we can then use to see if he is already registered
* The user is **not** logged in, so we call the matching method `match_values_to_partner(...)` from `res.partner.match` to get the `partner_id` and see if he is already registered

# Misc
Took advantage of the changes to improve the UX a bit in the case where the user is already logged in, we use his information to pre-fill the registration form 