### PR TITLE
T1811 - Fix required zip_id in contacts

### DIFF
--- a/partner_compassion/models/partner_compassion.py
+++ b/partner_compassion/models/partner_compassion.py
@@ -483,8 +483,6 @@ class ResPartner(models.Model):
             {
                 # check if a state was found or not for this zip
                 "state_id": state.id if len(state) == 1 else None,
-                # remove this field value since its only used for the UI
-                "zip_id": None,
             }
         )
         return vals


### PR DESCRIPTION
# Description
There is a weird bug where after creating a new contact, we cannot access any other tab for that because because we are missing the `zip_id`.

# Technical Aspects
The issue comes from the changes made in this [PR](https://github.com/CompassionCH/compassion-switzerland/pull/1652), now that `zip_id` is a required field when all related fields are set, it needs to be saved in the database.