### PR TITLE
T1863 - Cannot create sponsorship for new partner (1/2)

### DIFF
--- a/partner_compassion/models/partner_compassion.py
+++ b/partner_compassion/models/partner_compassion.py
@@ -181,6 +181,8 @@ class ResPartner(models.Model):
         help="Tells whether the partner has less than 25 years.",
     )
 
+    company_id = fields.Many2one(default=lambda self: self.env.company)
+
     ##########################################################################
     #                             FIELDS METHODS                             #
     ##########################################################################

--- a/sponsorship_switzerland/models/contracts.py
+++ b/sponsorship_switzerland/models/contracts.py
@@ -89,7 +89,7 @@ class RecurringContracts(models.Model):
             if sponsorship.child_id.hold_id:
                 hold_expiration = sponsorship.child_id.hold_id.expiration_date
                 sponsorship.next_waiting_reminder = fields.Datetime.to_string(
-                    hold_expiration + relativedelta(years=7)
+                    hold_expiration - relativedelta(days=7)
                 )
             else:
                 sponsorship.next_waiting_reminder = False

--- a/sponsorship_switzerland/models/contracts.py
+++ b/sponsorship_switzerland/models/contracts.py
@@ -89,7 +89,7 @@ class RecurringContracts(models.Model):
             if sponsorship.child_id.hold_id:
                 hold_expiration = sponsorship.child_id.hold_id.expiration_date
                 sponsorship.next_waiting_reminder = fields.Datetime.to_string(
-                    hold_expiration - relativedelta(days=7)
+                    hold_expiration + relativedelta(years=7)
                 )
             else:
                 sponsorship.next_waiting_reminder = False


### PR DESCRIPTION
# Description
The SDS team encountered an issue for a french partner where they could not create a sponsorship for that partner, an error message `missing company_id` would always pop up preventing it from being created.

# Technical Aspects
It seems that for non-swiss partners there are two issues that make it so that sponsorships cannot be created.

The first issue is that all partners should have their `company_id` set as the "current company", so in our case _Compassion Switzerland_ and probably _Compassion Nordic_ for the nordics (I haven't tested that since I only have the swiss DB). 

The second issue (fixed in [compassion-account PR](https://github.com/CompassionCH/compassion-accounting/pull/244)) is that the recurring contract "inherits" the `company_id` of the partner's country, and since there is no company linked to that country (or any country other than switzerland) it is set to `null`. 

# Misc
An SQL query should be made to fix the partners without a `company_id` as such :
```sql
UPDATE res_partner rp SET rp.company_id=1 WHERE rp.company_id IS NULL;
```
I didn't make it a migration since I'm not sure if it is the same id for the nordics.