### PR TITLE
T1823 - Fix Biennial signature for physical print 

### DIFF
--- a/partner_communication_switzerland/models/res_users.py
+++ b/partner_communication_switzerland/models/res_users.py
@@ -130,11 +130,13 @@ class ResUsers(models.Model):
                     template.remove("#photo")
                 user.signature = template.html().format(**values)
 
+    @api.depends_context("lang")
     def _compute_short_signature(self):
         for user in self:
             template = PyQuery(user.signature)
             user.short_signature = template("#short").html()
 
+    @api.depends_context("lang")
     def _compute_signature_letter(self):
         """Translate country in Signature (for Compassion Switzerland)"""
         for user in self:


### PR DESCRIPTION
# Description
Seems like not all issues were fixed in https://github.com/CompassionCH/compassion-switzerland/pull/1662. When printing "physical" letters, the signatures still only used one language being the first one that is printed.

# Technical Aspects
The fixes we made in the previous PR was for `_compute_signature` which is used in the **email** signature, here we apply the same fix for `_compute_signature_letter` which is used by the **physical** letters.