### PR TITLE
T1955 - Fix unit tests

### DIFF
--- a/partner_communication_switzerland/tests/test_bug_fixes.py
+++ b/partner_communication_switzerland/tests/test_bug_fixes.py
@@ -10,7 +10,6 @@
 import base64
 import logging
 from base64 import b64decode
-
 from unittest import mock
 
 from odoo import fields

--- a/partner_communication_switzerland/tests/test_bug_fixes.py
+++ b/partner_communication_switzerland/tests/test_bug_fixes.py
@@ -11,7 +11,7 @@ import base64
 import logging
 from base64 import b64decode
 
-import mock
+from unittest import mock
 
 from odoo import fields
 from odoo.tools import file_open

--- a/partner_communication_switzerland/tests/test_hold_expiration.py
+++ b/partner_communication_switzerland/tests/test_hold_expiration.py
@@ -7,7 +7,7 @@
 #    The licence is in the file __manifest__.py
 #
 ##############################################################################
-import mock
+from unittest import mock
 
 from odoo.addons.child_compassion.models.compassion_hold import HoldType
 from odoo.addons.sponsorship_compassion.tests.test_sponsorship_compassion import (

--- a/partner_communication_switzerland/tests/test_lifecycle_events.py
+++ b/partner_communication_switzerland/tests/test_lifecycle_events.py
@@ -7,7 +7,7 @@
 #    The licence is in the file __manifest__.py
 #
 ##############################################################################
-import mock
+from unittest import mock
 
 from odoo.addons.sponsorship_compassion.tests.test_sponsorship_compassion import (
     BaseSponsorshipTest,

--- a/partner_communication_switzerland/tests/test_onboarding.py
+++ b/partner_communication_switzerland/tests/test_onboarding.py
@@ -7,7 +7,7 @@
 #    The licence is in the file __manifest__.py
 #
 ##############################################################################
-import mock
+from unittest import mock
 
 from odoo.addons.sponsorship_compassion.tests.test_sponsorship_compassion import (
     BaseSponsorshipTest,

--- a/partner_communication_switzerland/tests/test_sms_communication.py
+++ b/partner_communication_switzerland/tests/test_sms_communication.py
@@ -8,7 +8,6 @@
 #
 ##############################################################################
 import logging
-
 from unittest.mock import patch
 
 from odoo.tests import TransactionCase

--- a/partner_communication_switzerland/tests/test_sms_communication.py
+++ b/partner_communication_switzerland/tests/test_sms_communication.py
@@ -9,7 +9,7 @@
 ##############################################################################
 import logging
 
-from mock import patch
+from unittest.mock import patch
 
 from odoo.tests import TransactionCase
 

--- a/partner_communication_switzerland/tests/test_sms_provider.py
+++ b/partner_communication_switzerland/tests/test_sms_provider.py
@@ -6,7 +6,7 @@
 #    The licence is in the file __manifest__.py
 #
 ##############################################################################
-import mock
+from unittest import mock
 
 from odoo.tests import HttpCase
 

--- a/partner_compassion/tests/test_partner_compassion.py
+++ b/partner_compassion/tests/test_partner_compassion.py
@@ -8,7 +8,6 @@
 ##############################################################################
 
 import logging
-
 from unittest.mock import patch
 
 from odoo.tests import tagged

--- a/partner_compassion/tests/test_partner_compassion.py
+++ b/partner_compassion/tests/test_partner_compassion.py
@@ -9,7 +9,7 @@
 
 import logging
 
-from mock import patch
+from unittest.mock import patch
 
 from odoo.tests import tagged
 

--- a/sms_939/tests/test_sms_notification.py
+++ b/sms_939/tests/test_sms_notification.py
@@ -12,7 +12,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 
-import mock
+from unittest import mock
 
 from odoo.fields import Datetime
 from odoo.tests import HttpCase

--- a/sms_939/tests/test_sms_notification.py
+++ b/sms_939/tests/test_sms_notification.py
@@ -11,7 +11,6 @@ import logging
 import urllib.error
 import urllib.parse
 import urllib.request
-
 from unittest import mock
 
 from odoo.fields import Datetime

--- a/sponsorship_switzerland/tests/test_contracts_switzerland.py
+++ b/sponsorship_switzerland/tests/test_contracts_switzerland.py
@@ -9,7 +9,7 @@
 
 import datetime
 
-import mock
+from unittest import mock
 
 from odoo.addons.sponsorship_compassion.tests.test_sponsorship_compassion import (
     BaseSponsorshipTest,

--- a/sponsorship_switzerland/tests/test_contracts_switzerland.py
+++ b/sponsorship_switzerland/tests/test_contracts_switzerland.py
@@ -8,7 +8,6 @@
 ##############################################################################
 
 import datetime
-
 from unittest import mock
 
 from odoo.addons.sponsorship_compassion.tests.test_sponsorship_compassion import (

--- a/wordpress_connector/tests/test_wordress_connector.py
+++ b/wordpress_connector/tests/test_wordress_connector.py
@@ -9,7 +9,7 @@
 
 import logging
 
-import mock
+from unittest import mock
 
 from odoo import fields
 

--- a/wordpress_connector/tests/test_wordress_connector.py
+++ b/wordpress_connector/tests/test_wordress_connector.py
@@ -8,7 +8,6 @@
 ##############################################################################
 
 import logging
-
 from unittest import mock
 
 from odoo import fields


### PR DESCRIPTION
Fixed:
- `import mock` -> `from unittest import mock`: The mock library is in the python stdlib under unittest since python 3.3 (https://docs.python.org/3.3/library/unittest.mock.html)

See also: https://github.com/CompassionCH/compassion-modules/pull/1990