### PR TITLE
With the new strict ref matching, overriding the partner_ref with the…

### DIFF
--- a/sponsorship_switzerland/models/completion_rules.py
+++ b/sponsorship_switzerland/models/completion_rules.py
@@ -131,8 +131,6 @@ class StatementCompletionRule(models.Model):
             inv_line_data["analytic_account_id"] = analytic.analytic_id.id
         if analytic.analytic_tag_ids:
             inv_line_data["analytic_tag_ids"] = [(6, 0, analytic.analytic_tag_ids.ids)]
-
-        res_dict["payment_ref"] = product.name
         return inv_line_data
 
     def _find_product_id(self, partner_ref, ref):

--- a/sponsorship_switzerland/models/completion_rules.py
+++ b/sponsorship_switzerland/models/completion_rules.py
@@ -101,7 +101,7 @@ class StatementCompletionRule(models.Model):
             "payment_mode_id": self.env["account.payment.mode"]
             .search([("name", "=", "BVR")])
             .id,
-            "ref": ref,
+            "payment_reference": ref,
             "invoice_origin": stmts_vals["name"],
             "invoice_line_ids": [
                 (0, 0, self._generate_invoice_line(res, product, st_line, partner.id))


### PR DESCRIPTION
… product name hinder the reconciliation.