### PR TITLE
[T1993] : Auto-generate payment slip for 'Christmas Gift Fund' requests

### DIFF
--- a/report_compassion/__manifest__.py
+++ b/report_compassion/__manifest__.py
@@ -38,6 +38,7 @@
         "sponsorship_switzerland",  # compassion-switzerland
         "report_wkhtmltopdf_param",  # addons_oca
         "l10n_ch",
+        "crm_request",
     ],
     "external_dependencies": {"python": ["pyquery", "babel"]},
     "data": [
@@ -49,6 +50,7 @@
         "report/partner_communication.xml",
         "report/bvr_gift.xml",
         "report/anniversary_card.xml",
+        "report/bvr_christmas.xml",
         "report/bvr_fund.xml",
         "report/new_donors_card.xml",
         "report/tax_receipt.xml",

--- a/report_compassion/report/bvr_christmas.xml
+++ b/report_compassion/report/bvr_christmas.xml
@@ -1,0 +1,30 @@
+<odoo>
+    <record id="report_bvr_fund_christmas" model="ir.actions.report">
+        <field name="name">Payment Slip for Christmas Fund</field>
+        <field name="model">crm.claim</field>
+        <field name="report_type">qweb-pdf</field>
+        <field name="report_name">report_compassion.bvr_fund_christmas</field>
+        <field name="paperformat_id" ref="paperformat_single_bvr_sponsorship" />
+    </record>
+
+    <template id="bvr_fund_christmas">
+        <t t-name="report_compassion.bvr_fund_christmas">
+            <t t-call="web.html_container">
+                <t t-call="web.external_layout">
+                    <t
+            t-set="product"
+            t-value="docs.env['product.product'].browse([31])"
+          />
+                    <t t-foreach="docs" t-as="claim">
+                        <t
+              t-call="report_compassion.report_bvr_fund_document"
+              t-lang="claim.partner_id.lang"
+            >
+                            <t t-set="doc" t-value="claim.partner_id" />
+                        </t>
+                    </t>
+                </t>
+            </t>
+        </t>
+    </template>
+</odoo>


### PR DESCRIPTION
A fix has been made to ensure the payment slip for the 'Christmas Gift Fund' category is automatically generated when a support request is received. Previously, the slip had to be manually generated under the sponsor's profile, causing inefficiencies in the workflow.

The fix has been implemented through an XML file "bvr_christmas.xml", which defines the report action and template. Be careful to verify if the product ID (currently set to 31) is correct in the production environment to avoid potential issues. 

Additionally, the payment slip template may need to be reconfigured in production to ensure proper functionality.