### PR TITLE
[T0047] refactor xlmrpc call using REST API instead

### DIFF
--- a/child_sync_wp/models/child_compassion.py
+++ b/child_sync_wp/models/child_compassion.py
@@ -58,23 +58,35 @@ class CompassionChild(models.Model):
 
         wp_config = self.env["wordpress.configuration"].get_config(company_id)
         wp = WPSync(wp_config)
-        return wp.upload_children(valid_children)
+        return wp.upload_children(self)
 
     def remove_from_wordpress(self):
-        valid_children = self.filtered(lambda c: c.state == "I")
-        if valid_children:
-            wp_config = self.env["wordpress.configuration"].get_config()
-            wp = WPSync(wp_config)
-            if wp.remove_children(valid_children):
-                valid_children.write({"state": "N"})
-        return True
+        try:
+            valid_children = self.filtered(lambda c: c.state == "I")
+            if valid_children:
+                wp_config = self.env["wordpress.configuration"].get_config()
+                wp = WPSync(wp_config)
+                if wp.remove_children(valid_children):
+                    valid_children.write({"state": "N"})
+            return True
+        except Exception as e:
+            logger.error(f"Error removing children from WordPress: {e}", exc_info=True)
+            raise
 
     def force_remove_from_wordpress(self, company_id=None):
-        wp_config = self.env["wordpress.configuration"].get_config(company_id)
-        wp = WPSync(wp_config)
-        if wp.remove_all_children():
-            self.write({"state": "N"})
-        return True
+        try:
+            wp_config = self.env["wordpress.configuration"].get_config(company_id)
+            wp = WPSync(wp_config)
+            if wp.remove_all_children():
+                logger.info("ALL CHILDREN REMOVED")
+                self.write({"state": "N"})
+            return True
+        except Exception as e:
+            logger.error(
+                f"Error force removing children from WordPress: {e}",
+                exc_info=True,
+            )
+            raise
 
     def child_sponsored(self, sponsor_id):
         """Remove children from the website when they are sponsored."""
@@ -117,7 +129,7 @@ class CompassionChild(models.Model):
                 int(take)
             )
             self.with_delay(
-                channel="root.gmc_pool.child_compassion",
+                channel="root.child_compassion",
                 description="Hold and push children to wordpress",
             )._hold_and_push_to_wordpress(company.id, global_pool)
             return True

--- a/child_sync_wp/models/child_compassion.py
+++ b/child_sync_wp/models/child_compassion.py
@@ -58,7 +58,7 @@ class CompassionChild(models.Model):
 
         wp_config = self.env["wordpress.configuration"].get_config(company_id)
         wp = WPSync(wp_config)
-        return wp.upload_children(self)
+        return wp.upload_children(valid_children)
 
     def remove_from_wordpress(self):
         try:

--- a/child_sync_wp/tools/wp_sync.py
+++ b/child_sync_wp/tools/wp_sync.py
@@ -1,5 +1,4 @@
 import logging
-from datetime import datetime
 
 import requests
 
@@ -83,8 +82,7 @@ class WPSync(object):
                         "first_name": child.preferred_name,
                         "name": child.name,
                         "full_name": child.name,
-                        "birthday": datetime.combine(
-                            child.birthdate, datetime.min.time()).timestamp(),
+                        "birthday": serialize_date(child.birthdate),
                         "gender": child.gender,
                         "start_date": serialize_date(
                             child.unsponsored_since or child.date

--- a/child_sync_wp/tools/wp_sync.py
+++ b/child_sync_wp/tools/wp_sync.py
@@ -82,7 +82,7 @@ class WPSync(object):
                         "first_name": child.preferred_name,
                         "name": child.name,
                         "full_name": child.name,
-                        "birthday": serialize_date(child.birthdate),
+                        "birthday": child.birthdate.timestamp(),
                         "gender": child.gender,
                         "start_date": serialize_date(
                             child.unsponsored_since or child.date

--- a/child_sync_wp/tools/wp_sync.py
+++ b/child_sync_wp/tools/wp_sync.py
@@ -35,7 +35,7 @@ class WPSync(object):
                 "password": self.wp_config.password,
             }
             headers = {"Content-Type": "application/json", "Accept": "application/json"}
-            response = requests.post(url, json=payload, headers=headers, verify=False)
+            response = requests.post(url, json=payload, headers=headers)
             response.raise_for_status()
             data = response.json()
             self.token = data.get("token")
@@ -46,7 +46,7 @@ class WPSync(object):
             _logger.error(
                 "JWT Auth Failure : %s\nResponse: %s",
                 e,
-                response.text if response is not None else "No reponse",
+                response.text if response is not None else "No response",
                 exc_info=True,
             )
             raise
@@ -101,7 +101,6 @@ class WPSync(object):
                         self.base_url + "add-child",
                         json=payload,
                         headers=self.get_headers(),
-                        verify=False,
                     )
                     response.raise_for_status()
                     resp_data = response.json()

--- a/child_sync_wp/tools/wp_sync.py
+++ b/child_sync_wp/tools/wp_sync.py
@@ -21,8 +21,8 @@ class WPSync(object):
          - password
         """
         self.wp_config = wp_config
-        self.base_url = "http://{}/wp-json/child-import/v1/".format(wp_config.host)
-        self.jwt_url = "http://{}/wp-json/jwt-auth/v1/".format(wp_config.host)
+        self.base_url = "https://{}/wp-json/child-import/v1/".format(wp_config.host)
+        self.jwt_url = "https://{}/wp-json/jwt-auth/v1/".format(wp_config.host)
         self.token = None
         self.authenticate()
 
@@ -135,8 +135,7 @@ class WPSync(object):
                 self.base_url + "delete-children",
                 json=payload,
                 headers=self.get_headers(),
-                # TODO set to True for prod
-                verify=False,
+                verify=True,
             )
             response.raise_for_status()
             res_data = response.json()
@@ -151,8 +150,7 @@ class WPSync(object):
             response = requests.delete(
                 self.base_url + "delete-all-children",
                 headers=self.get_headers(),
-                # TODO set to True for prod
-                verify=False,
+                verify=True,
             )
             response.raise_for_status()
             res_data = response.json()

--- a/child_sync_wp/tools/wp_sync.py
+++ b/child_sync_wp/tools/wp_sync.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import datetime
 
 import requests
 
@@ -82,7 +83,8 @@ class WPSync(object):
                         "first_name": child.preferred_name,
                         "name": child.name,
                         "full_name": child.name,
-                        "birthday": child.birthdate.timestamp(),
+                        "birthday": datetime.combine(
+                            child.birthdate, datetime.min.time()).timestamp(),
                         "gender": child.gender,
                         "start_date": serialize_date(
                             child.unsponsored_since or child.date

--- a/child_sync_wp/tools/wp_sync.py
+++ b/child_sync_wp/tools/wp_sync.py
@@ -1,75 +1,79 @@
-##############################################################################
-#
-#    Copyright (C) 2016 Compassion CH (http://www.compassion.ch)
-#    Releasing children from poverty in Jesus' name
-#    @author: Emanuel Cino <ecino@compassion.ch>
-#
-#    The licence is in the file __manifest__.py
-#
-##############################################################################
 import logging
-from xmlrpc.client import GzipDecodedResponse, SafeTransport, ServerProxy
+
+import requests
 
 _logger = logging.getLogger(__name__)
 
 
-# Solves XMLRPC Parse response problems by stripping response
-class CustomTransport(SafeTransport):
-    def parse_response(self, response):
-        # read response data from httpresponse, and parse it
-
-        # Check for new http response object, else it is a file object
-        if hasattr(response, "getheader"):
-            if response.getheader("Content-Encoding", "") == "gzip":
-                stream = GzipDecodedResponse(response)
-            else:
-                stream = response
-        else:
-            stream = response
-
-        p, u = self.getparser()
-
-        while 1:
-            data = stream.read(1024)
-            data = data.strip()
-            if not data:
-                break
-            if self.verbose:
-                _logger.info("body: " + repr(data))
-            p.feed(data)
-
-        if stream is not response:
-            stream.close()
-        p.close()
-
-        return u.close()
+def serialize_date(date_obj):
+    """Convertit un objet date/datetime en chaîne ISO 8601."""
+    if date_obj and hasattr(date_obj, "isoformat"):
+        return date_obj.isoformat()
+    return str(date_obj) if date_obj else None
 
 
 class WPSync(object):
     def __init__(self, wp_config):
-        self.xmlrpc_server = ServerProxy(
-            "https://" + wp_config.host + "/xmlrpc.php", transport=CustomTransport()
-        )
-        self.user = wp_config.user
-        self.pwd = wp_config.password
+        """
+        wp_config should be defined :
+         - host
+         - user
+         - password
+        """
+        self.wp_config = wp_config
+        self.base_url = "http://{}/wp-json/child-import/v1/".format(wp_config.host)
+        self.jwt_url = "http://{}/wp-json/jwt-auth/v1/".format(wp_config.host)
+        self.token = None
+        self.authenticate()
 
-    def test_xmlrpc(self):
-        return self.xmlrpc_server.demo.sayHello()
+    def authenticate(self):
+        """Get JWT token for auth."""
+        try:
+            url = self.jwt_url + "token"
+            payload = {
+                "username": self.wp_config.user,
+                "password": self.wp_config.password,
+            }
+            headers = {"Content-Type": "application/json", "Accept": "application/json"}
+            response = requests.post(url, json=payload, headers=headers, verify=False)
+            response.raise_for_status()
+            data = response.json()
+            self.token = data.get("token")
+            if not self.token:
+                raise Exception("No token found in the response : {}".format(data))
+            _logger.info("JWT received.")
+        except Exception as e:
+            _logger.error(
+                "JWT Auth Failure : %s\nResponse: %s",
+                e,
+                response.text if response is not None else "No reponse",
+                exc_info=True,
+            )
+            raise
+
+    def get_headers(self):
+        """Prepare headers with token JWT."""
+        if not self.token:
+            self.authenticate()
+        return {
+            "Authorization": "Bearer " + self.token,
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
 
     def upload_children(self, children):
         """Push children to Wordpress website.
 
-        1 - Create dictionary and send to Wordpress through XMLRPC method
+        1 - Create dictionary and send to Wordpress (REST API)
         2 - Image URL (from Cloudinary) is now part of the post insert and
         not uploaded as file anymore
 
         :param children: compassion.child recordset
-        :return: result of xmlrpc call to wordpress (true/false)
+        :return: result of call to wordpress (true/false)
         """
         count_insert = 0
-
-        for child in children:
-            _logger.info("Pushing child %s/%s", count_insert + 1, len(children))
+        for index, child in enumerate(children, start=1):
+            _logger.info("Pushing child %s/%s", index, len(children))
             try:
                 with children.env.cr.savepoint():
                     child_values = {
@@ -78,59 +82,82 @@ class WPSync(object):
                         "first_name": child.preferred_name,
                         "name": child.name,
                         "full_name": child.name,
-                        "birthday": child.birthdate,
+                        "birthday": serialize_date(child.birthdate),
                         "gender": child.gender,
-                        # CO-1003 in case child has no unsponsored_since date,
-                        # we use allocation date
-                        "start_date": child.unsponsored_since or child.date,
-                        "desc": child.description_fr,
-                        "desc_de": child.description_de,
-                        "desc_it": child.description_it,
+                        "start_date": serialize_date(
+                            child.unsponsored_since or child.date
+                        ),
+                        "desc": child.description_fr or "test",
+                        "desc_de": child.description_de or "test",
+                        "desc_it": child.description_it or "test",
                         "country": child.project_id.country_id.name,
                         "project": child.project_id.description_fr,
                         "project_de": child.project_id.description_de,
                         "project_it": child.project_id.description_it,
                         "cloudinary_url": child.image_url,
                     }
-                    if self.xmlrpc_server.child_import.addChild(
-                        self.user, self.pwd, child_values
-                    ):
+                    payload = {"child": child_values}
+                    response = requests.post(
+                        self.base_url + "add-child",
+                        json=payload,
+                        headers=self.get_headers(),
+                        verify=False,
+                    )
+                    response.raise_for_status()
+                    resp_data = response.json()
+                    if resp_data.get("success") is True:
                         count_insert += 1
                         child.state = "I"
             except Exception:
-                _logger.error("Child Upload failed: ", exc_info=True)
+                _logger.error("Child Upload failed", exc_info=True)
 
         if count_insert == len(children):
             _logger.info(
                 f"Child Upload on Wordpress finished: {count_insert} children "
                 "imported "
             )
+        elif (count_insert > 0) and (count_insert < len(children)):
+            _logger.warning(
+                "Child Upload partially failed."
+                + str(count_insert)
+                + " of "
+                + str(len(children))
+            )
         else:
-            if (count_insert > 0) and (count_insert < len(children)):
-                _logger.warning(
-                    "Child Upload partially failed."
-                    + str(count_insert)
-                    + " of "
-                    + str(len(children))
-                )
-            else:
-                _logger.error("Child Upload failed.")
+            _logger.error("Child Upload failed.")
 
         return count_insert
 
     def remove_children(self, children):
         try:
-            res = self.xmlrpc_server.child_import.deleteChildren(
-                self.user, self.pwd, children.mapped("local_id")
+            payload = {"children": children.mapped("local_id")}
+            response = requests.delete(
+                self.base_url + "delete-children",
+                json=payload,
+                headers=self.get_headers(),
+                # TODO set to True for prod
+                verify=False,
             )
-            _logger.info("Remove from Wordpress : " + str(res))
-            return res
+            response.raise_for_status()
+            res_data = response.json()
+            _logger.info("Remove from Wordpress : " + str(res_data))
+            return res_data
         except Exception:
-            _logger.error("Remove from Wordpress failed.", exc_info=True)
-
-        return False
+            _logger.error("Remove from WordPress failed", exc_info=True)
+            return False
 
     def remove_all_children(self):
-        res = self.xmlrpc_server.child_import.deleteAllChildren(self.user, self.pwd)
-        _logger.info("Remove from Wordpress : " + str(res))
-        return res
+        try:
+            response = requests.delete(
+                self.base_url + "delete-all-children",
+                headers=self.get_headers(),
+                # TODO set to True for prod
+                verify=False,
+            )
+            response.raise_for_status()
+            res_data = response.json()
+            _logger.info("Removed all children from Wordpress : " + str(res_data))
+            return res_data
+        except Exception:
+            _logger.error("Remove all children from WordPress failed", exc_info=True)
+            return False

--- a/setup/auth_external/odoo/addons/auth_external
+++ b/setup/auth_external/odoo/addons/auth_external
@@ -1,0 +1,1 @@
+../../../../auth_external

--- a/setup/auth_external/setup.py
+++ b/setup/auth_external/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
Replaced the XML-RPC calls with a REST API.

Handled upload and removal of children from Odoo to WordPress.
The endpoints have been created on the WordPress side—please refer to the PR linked in the Google Doc.

⚠️ 
Please pay attention to the remaining #TODO comments in the code.
Worked locally but please do some more tests