### PR TITLE
[T2168] Ending Sponsorship Certificate can be printed and translated

### DIFF
--- a/partner_communication_switzerland/models/partner_communication.py
+++ b/partner_communication_switzerland/models/partner_communication.py
@@ -367,6 +367,7 @@ class PartnerCommunication(models.Model):
             "doc_ids": sponsorships.ids,
             "long_lasting": max(sponsorships.mapped("contract_duration")) >= 730,
             "new_version": new_version,
+            "communication_generated": True
         }
         pdf = self._get_pdf_from_data(
             data,

--- a/partner_communication_switzerland/models/partner_communication.py
+++ b/partner_communication_switzerland/models/partner_communication.py
@@ -367,7 +367,7 @@ class PartnerCommunication(models.Model):
             "doc_ids": sponsorships.ids,
             "long_lasting": max(sponsorships.mapped("contract_duration")) >= 730,
             "new_version": new_version,
-            "communication_generated": True
+            "communication_generated": True,
         }
         pdf = self._get_pdf_from_data(
             data,

--- a/report_compassion/models/__init__.py
+++ b/report_compassion/models/__init__.py
@@ -19,5 +19,5 @@ from . import (
     report_bvr_sponsorship_gift,
     report_tax_receipt,
     res_partner,
-    ending_sponsorship_certificate
+    ending_sponsorship_certificate,
 )

--- a/report_compassion/models/__init__.py
+++ b/report_compassion/models/__init__.py
@@ -19,4 +19,5 @@ from . import (
     report_bvr_sponsorship_gift,
     report_tax_receipt,
     res_partner,
+    ending_sponsorship_certificate
 )

--- a/report_compassion/models/ending_sponsorship_certificate.py
+++ b/report_compassion/models/ending_sponsorship_certificate.py
@@ -1,0 +1,74 @@
+from odoo import models, api, _
+from babel.dates import format_date
+from odoo.exceptions import UserError
+
+class ReportEndingSponsorshipCertificate(models.TransientModel):
+    _name = 'report.report_compassion.ending_sponsorship_certificate'
+    _description = 'Ending Sponsorship Certificate Report'
+
+    @api.model
+    def _get_report_values(self, docids, data=None):
+        docs = self.env['recurring.contract'].browse(docids)
+
+        values = []
+
+        partner_lang = "en_US"
+
+        paragraph_one = {
+            "en_US": f"We thank you from the bottom of our hearts for accompanying a child living in poverty.",
+            "fr_CH": f"Nous vous remercions du fond du cœur d'avoir accompagné un enfant vivant dans la pauvreté.",
+            "de_DE": f"Wir danken dir von ganzem Herzen, dass du ein Kind, das in Armut lebt, begleitet hast.",
+            "it_IT": f"Grazie di cuore per aver accompagnato un bambino che vive in estrema povertà.",
+        }
+        paragraph_two = {
+            "en_US": f"Your precious commitment has given dignity to this child, helped him to develop in a promising way and allowed him to look forward to the future with hope.",
+            "fr_CH": f"Votre précieux engagement a donné de la dignité à cet enfant, l'a aidé à se développer de manière prometteuse et lui a permis d'envisager l'avenir avec espérance.",
+            "de_DE": f"Dein wertvoller Einsatz hat diesem Kind Würde gegeben, ihm zu einer vielversprechenden Entwicklung verholfen und ihm ermöglicht, mit Hoffnung in die Zukunft zu blicken.",
+            "it_IT": f"Il tuo prezioso impegno gli ha ridato dignità, lo ha aiutato a svilupparsi in modo promettente e gli ha permesso di guardare al futuro con speranza.",
+        }
+        paragraph_three = {
+            "en_US": f"We thank you from the bottom of our hearts for accompanying a child living in poverty.",
+            "fr_CH": f"Nous vous remercions du fond du cœur d'avoir accompagné un enfant vivant dans la pauvreté.",
+            "de_DE": f"Wir danken dir von ganzem Herzen, dass du ein Kind, das in Armut lebt, begleitet hast.",
+            "it_IT": f"Grazie di cuore per aver accompagnato un bambino che vive in estrema povertà.",
+        }
+
+
+
+        for doc in docs:
+
+            if not doc.end_date:
+                raise UserError(_("End date is required for generating the certificate"))
+
+            if doc.start_date:
+                effective_start_date = doc.start_date
+            elif doc.activation_date:
+                effective_start_date = doc.activation_date
+            else:
+                raise UserError(_("Either start date or activation date is required for generating the certificate"))
+
+            if doc.partner_id.lang:
+                partner_lang = doc.partner_id.lang
+
+            text = (f"<p>{paragraph_one[partner_lang]}</p>"
+                    f"<p class = second_paragraph>{paragraph_two[partner_lang]}</p>"
+                    )
+            long_lasting_text = (f"{paragraph_three[partner_lang]}")
+
+            values.append({
+                'doc': doc,
+                'long_lasting': doc.contract_duration >= 730,
+                'gender': doc.child_id.gender if doc.child_id else 'Unknown',
+                'start_date': format_date(effective_start_date, format='MMMM d, yyyy', locale=partner_lang),
+                'end_date': format_date(doc.end_date, format='MMMM d, yyyy', locale=partner_lang),
+                'pictures': doc.child_id.pictures_ids,
+                'child_name': doc.child_id.preferred_name,
+                'text': text,
+                'long_lasting_text' : long_lasting_text
+            })
+
+
+        return ({
+            'docs': values,
+            'lang': partner_lang,
+        })

--- a/report_compassion/models/ending_sponsorship_certificate.py
+++ b/report_compassion/models/ending_sponsorship_certificate.py
@@ -17,22 +17,42 @@ class ReportEndingSponsorshipCertificate(models.TransientModel):
         partner_lang = "en_US"
 
         paragraph_one = {
-            "en_US": "We thank you from the bottom of our hearts for accompanying a child living in poverty.",
-            "fr_CH": "Nous vous remercions du fond du cœur d'avoir accompagné un enfant vivant dans la pauvreté.",
-            "de_DE": "Wir danken dir von ganzem Herzen, dass du ein Kind, das in Armut lebt, begleitet hast.",
-            "it_IT": "Grazie di cuore per aver accompagnato un bambino che vive in estrema povertà.",
+            "en_US": "We thank you from the bottom of our "
+            "hearts for accompanying a child living in poverty.",
+            "fr_CH": "Nous vous remercions du fond du cœur "
+            "d'avoir accompagné un enfant vivant dans la pauvreté.",
+            "de_DE": "Wir danken dir von ganzem Herzen, dass du "
+            "ein Kind, das in Armut lebt, begleitet hast.",
+            "it_IT": "Grazie di cuore per aver accompagnato "
+            "un bambino che vive in estrema povertà.",
         }
         paragraph_two = {
-            "en_US": "Your precious commitment has given dignity to this child, helped him to develop in a promising way and allowed him to look forward to the future with hope.",
-            "fr_CH": "Votre précieux engagement a donné de la dignité à cet enfant, l'a aidé à se développer de manière prometteuse et lui a permis d'envisager l'avenir avec espérance.",
-            "de_DE": "Dein wertvoller Einsatz hat diesem Kind Würde gegeben, ihm zu einer vielversprechenden Entwicklung verholfen und ihm ermöglicht, mit Hoffnung in die Zukunft zu blicken.",
-            "it_IT": "Il tuo prezioso impegno gli ha ridato dignità, lo ha aiutato a svilupparsi in modo promettente e gli ha permesso di guardare al futuro con speranza.",
+            "en_US": "Your precious commitment has given "
+            "dignity to this child, helped him "
+            "to develop in a promising way and allowed "
+            "him to look forward to the future with hope.",
+            "fr_CH": "Votre précieux engagement a donné de la dignité "
+            "à cet enfant, l'a aidé à se développer "
+            "de manière prometteuse et lui a "
+            "permis d'envisager l'avenir avec espérance.",
+            "de_DE": "Dein wertvoller Einsatz hat diesem Kind Würde gegeben,"
+            " ihm zu einer vielversprechenden "
+            "Entwicklung verholfen und ihm ermöglicht, "
+            "mit Hoffnung in die Zukunft zu blicken.",
+            "it_IT": "Il tuo prezioso impegno gli ha "
+            "ridato dignità, lo ha aiutato a "
+            "svilupparsi in modo promettente e gli "
+            "ha permesso di guardare al futuro con speranza.",
         }
         paragraph_three = {
-            "en_US": "We thank you from the bottom of our hearts for accompanying a child living in poverty.",
-            "fr_CH": "Nous vous remercions du fond du cœur d'avoir accompagné un enfant vivant dans la pauvreté.",
-            "de_DE": "Wir danken dir von ganzem Herzen, dass du ein Kind, das in Armut lebt, begleitet hast.",
-            "it_IT": "Grazie di cuore per aver accompagnato un bambino che vive in estrema povertà.",
+            "en_US": "Do you remember the beginning of your sponsorship? "
+            "What a great journey it has been since then!",
+            "fr_CH": "Vous souvenez-vous du début de votre parrainage? "
+            "Quel beau chemin parcouru depuis!",
+            "de_DE": "Erinnerst du dich an den Beginn deiner Patenschaft? "
+            "Was für einen langen Weg haben wir seither zurückgelegt!",
+            "it_IT": "Ti ricordi l’inizio del tuo sostegno? "
+            "Quanta strada abbiamo fatto da allora!",
         }
 
         for doc in docs:
@@ -48,7 +68,8 @@ class ReportEndingSponsorshipCertificate(models.TransientModel):
             else:
                 raise UserError(
                     _(
-                        "Either start date or activation date is required for generating the certificate"
+                        "Either start date or activation date is "
+                        "required for generating the certificate"
                     )
                 )
 

--- a/report_compassion/models/ending_sponsorship_certificate.py
+++ b/report_compassion/models/ending_sponsorship_certificate.py
@@ -1,74 +1,85 @@
-from odoo import models, api, _
 from babel.dates import format_date
+
+from odoo import _, api, models
 from odoo.exceptions import UserError
 
+
 class ReportEndingSponsorshipCertificate(models.TransientModel):
-    _name = 'report.report_compassion.ending_sponsorship_certificate'
-    _description = 'Ending Sponsorship Certificate Report'
+    _name = "report.report_compassion.ending_sponsorship_certificate"
+    _description = "Ending Sponsorship Certificate Report"
 
     @api.model
     def _get_report_values(self, docids, data=None):
-        docs = self.env['recurring.contract'].browse(docids)
+        docs = self.env["recurring.contract"].browse(docids)
 
         values = []
 
         partner_lang = "en_US"
 
         paragraph_one = {
-            "en_US": f"We thank you from the bottom of our hearts for accompanying a child living in poverty.",
-            "fr_CH": f"Nous vous remercions du fond du cœur d'avoir accompagné un enfant vivant dans la pauvreté.",
-            "de_DE": f"Wir danken dir von ganzem Herzen, dass du ein Kind, das in Armut lebt, begleitet hast.",
-            "it_IT": f"Grazie di cuore per aver accompagnato un bambino che vive in estrema povertà.",
+            "en_US": "We thank you from the bottom of our hearts for accompanying a child living in poverty.",
+            "fr_CH": "Nous vous remercions du fond du cœur d'avoir accompagné un enfant vivant dans la pauvreté.",
+            "de_DE": "Wir danken dir von ganzem Herzen, dass du ein Kind, das in Armut lebt, begleitet hast.",
+            "it_IT": "Grazie di cuore per aver accompagnato un bambino che vive in estrema povertà.",
         }
         paragraph_two = {
-            "en_US": f"Your precious commitment has given dignity to this child, helped him to develop in a promising way and allowed him to look forward to the future with hope.",
-            "fr_CH": f"Votre précieux engagement a donné de la dignité à cet enfant, l'a aidé à se développer de manière prometteuse et lui a permis d'envisager l'avenir avec espérance.",
-            "de_DE": f"Dein wertvoller Einsatz hat diesem Kind Würde gegeben, ihm zu einer vielversprechenden Entwicklung verholfen und ihm ermöglicht, mit Hoffnung in die Zukunft zu blicken.",
-            "it_IT": f"Il tuo prezioso impegno gli ha ridato dignità, lo ha aiutato a svilupparsi in modo promettente e gli ha permesso di guardare al futuro con speranza.",
+            "en_US": "Your precious commitment has given dignity to this child, helped him to develop in a promising way and allowed him to look forward to the future with hope.",
+            "fr_CH": "Votre précieux engagement a donné de la dignité à cet enfant, l'a aidé à se développer de manière prometteuse et lui a permis d'envisager l'avenir avec espérance.",
+            "de_DE": "Dein wertvoller Einsatz hat diesem Kind Würde gegeben, ihm zu einer vielversprechenden Entwicklung verholfen und ihm ermöglicht, mit Hoffnung in die Zukunft zu blicken.",
+            "it_IT": "Il tuo prezioso impegno gli ha ridato dignità, lo ha aiutato a svilupparsi in modo promettente e gli ha permesso di guardare al futuro con speranza.",
         }
         paragraph_three = {
-            "en_US": f"We thank you from the bottom of our hearts for accompanying a child living in poverty.",
-            "fr_CH": f"Nous vous remercions du fond du cœur d'avoir accompagné un enfant vivant dans la pauvreté.",
-            "de_DE": f"Wir danken dir von ganzem Herzen, dass du ein Kind, das in Armut lebt, begleitet hast.",
-            "it_IT": f"Grazie di cuore per aver accompagnato un bambino che vive in estrema povertà.",
+            "en_US": "We thank you from the bottom of our hearts for accompanying a child living in poverty.",
+            "fr_CH": "Nous vous remercions du fond du cœur d'avoir accompagné un enfant vivant dans la pauvreté.",
+            "de_DE": "Wir danken dir von ganzem Herzen, dass du ein Kind, das in Armut lebt, begleitet hast.",
+            "it_IT": "Grazie di cuore per aver accompagnato un bambino che vive in estrema povertà.",
         }
 
-
-
         for doc in docs:
-
             if not doc.end_date:
-                raise UserError(_("End date is required for generating the certificate"))
+                raise UserError(
+                    _("End date is required for generating the certificate")
+                )
 
             if doc.start_date:
                 effective_start_date = doc.start_date
             elif doc.activation_date:
                 effective_start_date = doc.activation_date
             else:
-                raise UserError(_("Either start date or activation date is required for generating the certificate"))
+                raise UserError(
+                    _(
+                        "Either start date or activation date is required for generating the certificate"
+                    )
+                )
 
             if doc.partner_id.lang:
                 partner_lang = doc.partner_id.lang
 
-            text = (f"<p>{paragraph_one[partner_lang]}</p>"
-                    f"<p class = second_paragraph>{paragraph_two[partner_lang]}</p>"
-                    )
-            long_lasting_text = (f"{paragraph_three[partner_lang]}")
+            text = (
+                f"<p>{paragraph_one[partner_lang]}</p>"
+                f"<p class = second_paragraph>{paragraph_two[partner_lang]}</p>"
+            )
+            long_lasting_text = f"{paragraph_three[partner_lang]}"
 
-            values.append({
-                'doc': doc,
-                'long_lasting': doc.contract_duration >= 730,
-                'gender': doc.child_id.gender if doc.child_id else 'Unknown',
-                'start_date': format_date(effective_start_date, format='MMMM d, yyyy', locale=partner_lang),
-                'end_date': format_date(doc.end_date, format='MMMM d, yyyy', locale=partner_lang),
-                'pictures': doc.child_id.pictures_ids,
-                'child_name': doc.child_id.preferred_name,
-                'text': text,
-                'long_lasting_text' : long_lasting_text
-            })
+            values.append(
+                {
+                    "doc": doc,
+                    "long_lasting": doc.contract_duration >= 730,
+                    "gender": doc.child_id.gender if doc.child_id else "Unknown",
+                    "start_date": format_date(
+                        effective_start_date, format="MMMM d, yyyy", locale=partner_lang
+                    ),
+                    "end_date": format_date(
+                        doc.end_date, format="MMMM d, yyyy", locale=partner_lang
+                    ),
+                    "pictures": doc.child_id.pictures_ids,
+                    "child_name": doc.child_id.preferred_name,
+                    "text": text,
+                    "long_lasting_text": long_lasting_text,
+                }
+            )
 
-
-        return ({
-            'docs': values,
-            'lang': partner_lang,
-        })
+        return {
+            "docs": values,
+            "lang": partner_lang,
+        }

--- a/report_compassion/report/ending_sponsorship_certificate.xml
+++ b/report_compassion/report/ending_sponsorship_certificate.xml
@@ -122,11 +122,6 @@
           />
                 </div>
 
-        <t t-esc="lang"/>
-                <t t-esc="digital"/>
-                <t t-esc="communication_generated"/>
-        <t t-esc="o['long_lasting']"/>
-
                 <div
           class="text_layout"
         >

--- a/report_compassion/report/ending_sponsorship_certificate.xml
+++ b/report_compassion/report/ending_sponsorship_certificate.xml
@@ -6,7 +6,9 @@
         <field name="name">Ending Sponsorship Certificate</field>
         <field name="model">recurring.contract</field>
         <field name="report_type">qweb-pdf</field>
-        <field name="report_name">report_compassion.ending_sponsorship_certificate</field>
+        <field
+      name="report_name"
+    >report_compassion.ending_sponsorship_certificate</field>
         <field name="paperformat_id" ref="l10n_ch.paperformat_euro_no_margin" />
         <field name="binding_model_id" ref="model_recurring_contract" />
         <field name="binding_type">report</field>
@@ -115,31 +117,37 @@
             <t t-foreach="docs" t-as="o">
                 <t t-call="report_compassion.style" />
                 <t t-set="pictures" t-value="o['pictures']" />
-                <t t-set="first_pic_available" t-value="len(pictures) &gt; 1 and pictures[-1].date.year &lt; pictures[0].date.year"/>
+                <t
+          t-set="first_pic_available"
+          t-value="len(pictures) &gt; 1 and pictures[-1].date.year &lt; pictures[0].date.year"
+        />
                 <div class="background" t-if="digital">
                     <img
             t-attf-src="#{base_url}/report_compassion/static/img/report_compassion.ending_sponsorship_certificate/ending_sponsor_card_#{lang[:2]}.jpg"
           />
                 </div>
 
-                <div
-          class="text_layout"
-        >
-                    <t t-if="communication_generated and (new_version or digital or lang in ('it_IT', 'en_US', 'de_DE', 'fr_CH'))">
+                <div class="text_layout">
+                    <t
+            t-if="communication_generated and (new_version or digital or lang in ('it_IT', 'en_US', 'de_DE', 'fr_CH'))"
+          >
 
-                    <p>We thank you from the bottom of our hearts for accompanying a child living in poverty.</p>
-                   <p class="second_paragraph">Your precious commitment has given dignity to this child, helped him to develop in a promising way and allowed him to look forward to the future with hope.
+                    <p
+            >We thank you from the bottom of our hearts for accompanying a child living in poverty.</p>
+                   <p
+              class="second_paragraph"
+            >Your precious commitment has given dignity to this child, helped him to develop in a promising way and allowed him to look forward to the future with hope.
                     </p>
                     <p
-            class="third_paragraph"
-            t-if="o['long_lasting']"
-          >Do you remember the beginning of your sponsorship?<br
-            />What a great journey it has been since then!</p>
+              class="third_paragraph"
+              t-if="o['long_lasting']"
+            >Do you remember the beginning of your sponsorship?<br
+              />What a great journey it has been since then!</p>
                     </t>
                     <t t-else="">
-                        <t t-raw="o['text']"/>
+                        <t t-raw="o['text']" />
                     <p class="third_paragraph" t-if="o['long_lasting']">
-                    <t t-raw="o['long_lasting_text']"/>
+                    <t t-raw="o['long_lasting_text']" />
                     </p>
                     </t>
 
@@ -167,21 +175,19 @@
                 </div>
                 <div class="info_layout">
                     <p class="child_name">
-                        <t t-esc="o['child_name']"/>
+                        <t t-esc="o['child_name']" />
                     </p>
                     <hr class="yellow_line" />
                     <p class="legend_date">
-                        <t
-              t-if="o['gender'] == 'M'"
-            >
+                        <t t-if="o['gender'] == 'M'">
                             Sponsored since
                         </t>
-                        <t
-              t-if="o['gender'] == 'F'"
-            >
+                        <t t-if="o['gender'] == 'F'">
                             Sponsored since (Female)
                         </t>
-                        <t t-raw="o['start_date']" /> - <t t-raw="o['end_date']" /></p>
+                        <t t-raw="o['start_date']" /> - <t
+              t-raw="o['end_date']"
+            /></p>
                 </div>
             </t>
         </t>

--- a/report_compassion/report/ending_sponsorship_certificate.xml
+++ b/report_compassion/report/ending_sponsorship_certificate.xml
@@ -6,9 +6,7 @@
         <field name="name">Ending Sponsorship Certificate</field>
         <field name="model">recurring.contract</field>
         <field name="report_type">qweb-pdf</field>
-        <field
-      name="report_name"
-    >report_compassion.ending_sponsorship_certificate</field>
+        <field name="report_name">report_compassion.ending_sponsorship_certificate</field>
         <field name="paperformat_id" ref="l10n_ch.paperformat_euro_no_margin" />
         <field name="binding_model_id" ref="model_recurring_contract" />
         <field name="binding_type">report</field>
@@ -112,34 +110,47 @@
                 font-style: italic;
             }
         </t>
+
         <t t-call="web.html_container">
             <t t-foreach="docs" t-as="o">
                 <t t-call="report_compassion.style" />
-                <t t-set="pictures" t-value="o.child_id.pictures_ids" />
-                <t
-          t-set="first_pic_available"
-          t-value="len(pictures) &gt; 1 and pictures[-1].date.year &lt; pictures[0].date.year"
-        />
+                <t t-set="pictures" t-value="o['pictures']" />
+                <t t-set="first_pic_available" t-value="len(pictures) &gt; 1 and pictures[-1].date.year &lt; pictures[0].date.year"/>
                 <div class="background" t-if="digital">
                     <img
             t-attf-src="#{base_url}/report_compassion/static/img/report_compassion.ending_sponsorship_certificate/ending_sponsor_card_#{lang[:2]}.jpg"
           />
                 </div>
+
+        <t t-esc="lang"/>
+                <t t-esc="digital"/>
+                <t t-esc="communication_generated"/>
+        <t t-esc="o['long_lasting']"/>
+
                 <div
           class="text_layout"
-          t-if="new_version or digital or lang in ('it_IT', 'en_US')"
         >
-                    <p
-          >We thank you from the bottom of our hearts for accompanying a child living in poverty.</p>
-                    <p
-            class="second_paragraph"
-          >Your precious commitment has given dignity to this child, helped him to develop in a promising way and allowed him to look forward to the future with hope.</p>
+                    <t t-if="communication_generated and (new_version or digital or lang in ('it_IT', 'en_US', 'de_DE', 'fr_CH'))">
+
+                    <p>We thank you from the bottom of our hearts for accompanying a child living in poverty.</p>
+                   <p class="second_paragraph">Your precious commitment has given dignity to this child, helped him to develop in a promising way and allowed him to look forward to the future with hope.
+                    </p>
                     <p
             class="third_paragraph"
-            t-if="long_lasting"
+            t-if="o['long_lasting']"
           >Do you remember the beginning of your sponsorship?<br
             />What a great journey it has been since then!</p>
+                    </t>
+                    <t t-else="">
+                        <t t-raw="o['text']"/>
+                    <p class="third_paragraph" t-if="o['long_lasting']">
+                    <t t-raw="o['long_lasting_text']"/>
+                    </p>
+                    </t>
+
                 </div>
+
+
                 <div t-if="first_pic_available" class="pictures_layout">
                     <img
             t-if="pictures"
@@ -160,28 +171,22 @@
           />
                 </div>
                 <div class="info_layout">
-                    <p t-field="o.child_id.preferred_name" class="child_name" />
-                    <t
-            t-set="start_date"
-            t-value="o.env['connect.month'].get_months_selection()[o.start_date.month - 1][1]+' '+str(o.start_date.year)"
-          />
-                    <t
-            t-set="end_date"
-            t-value="o.env['connect.month'].get_months_selection()[o.end_date.month - 1][1]+' '+str(o.end_date.year)"
-          />
+                    <p class="child_name">
+                        <t t-esc="o['child_name']"/>
+                    </p>
                     <hr class="yellow_line" />
                     <p class="legend_date">
                         <t
-              t-if="o.child_id.gender == 'M' or lang not in ('fr_CH','it_IT')"
+              t-if="o['gender'] == 'M'"
             >
                             Sponsored since
                         </t>
                         <t
-              t-if="o.child_id.gender == 'F' and lang in ('fr_CH','it_IT')"
+              t-if="o['gender'] == 'F'"
             >
                             Sponsored since (Female)
                         </t>
-                        <t t-raw="start_date" /> - <t t-raw="end_date" /></p>
+                        <t t-raw="o['start_date']" /> - <t t-raw="o['end_date']" /></p>
                 </div>
             </t>
         </t>


### PR DESCRIPTION
Some methods were already created (with the translations working) for when generating a communication. But when you tried printing the certificate you would have nothing and the translation would not work. So I created a new model to handle the case where we want to print the report with translations working according to the partner's default language. 