### PR TITLE
[T2734] FIX: Volunteer content container

### DIFF
--- a/my_compassion_switzerland/templates/my2_volunteering.xml
+++ b/my_compassion_switzerland/templates/my2_volunteering.xml
@@ -45,7 +45,7 @@ Page: My Compassion 2 Volunteering Page
                             <p>Here's how you can get involved:</p>
                         </t>
                     </div>
-                    <div class="row text-center mb-3 mt-3">
+                    <div class="container-content row text-center mb-3 mt-3">
                         <t t-foreach="engagement_types" t-as="engagement_type">
                             <div class="col-12 col-md-6 col-lg-4 pb-4">
                                 <t


### PR DESCRIPTION
This PR fixes the column styling of the volunteer page by using the `container-content` styling class.

## **Desktop:**
<img width="2033" height="1291" alt="image" src="https://github.com/user-attachments/assets/22036755-cd14-4f63-8c76-50350ba1c43e" />

## **Moble:**
<img width="916" height="874" alt="image" src="https://github.com/user-attachments/assets/d29480d9-1c6e-4765-93b0-6abe8cda1294" />
<img width="430" height="891" alt="image" src="https://github.com/user-attachments/assets/b9be8a4e-d193-4fa2-8102-c5b08fe3bb94" />
