### PR TITLE
T2679 integrate e bill workflow into compassion switzerland

### DIFF
--- a/my_compassion_switzerland/__manifest__.py
+++ b/my_compassion_switzerland/__manifest__.py
@@ -19,6 +19,7 @@
         "my_compassion",
         "theme_compassion_2025",
         "partner_compassion",
+        "ebill_postfinance_recipient_subscription",
     ],
     "data": [
         "security/ir.model.access.csv",

--- a/my_compassion_switzerland/__manifest__.py
+++ b/my_compassion_switzerland/__manifest__.py
@@ -23,9 +23,12 @@
     "data": [
         "security/ir.model.access.csv",
         "security/access_rules.xml",
+        "data/account_payment_mode_data.xml",
         "views/advocate_engagement_view.xml",
         "templates/components/volunteering_card.xml",
         "templates/my2_volunteering.xml",
+        "templates/my2_new_sponsorship_wizard_ebill.xml",
+        "templates/assets.xml",
     ],
     "installable": True,
     "auto_install": False,

--- a/my_compassion_switzerland/data/account_payment_mode_data.xml
+++ b/my_compassion_switzerland/data/account_payment_mode_data.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="1">
+        <record id="payment_mode_ebill" model="account.payment.mode">
+            <field name="name">eBill</field>
+            <field name="company_id" ref="base.main_company"/>
+            <field name="bank_account_link">variable</field>
+            <field name="payment_method_id" ref="account.account_payment_method_manual_in"/>
+            <field name="active" eval="True"/>
+        </record>
+
+        <record id="account_payment_method_ebill" model="account.payment.method">
+            <field name="name">eBill</field>
+            <field name="code">ebill</field>
+            <field name="payment_type">inbound</field>
+        </record>
+    </data>
+</odoo>

--- a/my_compassion_switzerland/data/account_payment_mode_data.xml
+++ b/my_compassion_switzerland/data/account_payment_mode_data.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
-    <data noupdate="1">
+    <data>
         <record id="payment_mode_ebill" model="account.payment.mode">
-            <field name="name">eBill</field>
+            <field name="name">eBillasdfasdfasdf</field>
             <field name="company_id" ref="base.main_company" />
             <field name="bank_account_link">variable</field>
             <field
         name="payment_method_id"
-        ref="account.account_payment_method_manual_in"
+        ref="account_payment_method_ebill"
       />
             <field name="active" eval="True" />
         </record>

--- a/my_compassion_switzerland/data/account_payment_mode_data.xml
+++ b/my_compassion_switzerland/data/account_payment_mode_data.xml
@@ -1,15 +1,21 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8" ?>
 <odoo>
     <data noupdate="1">
         <record id="payment_mode_ebill" model="account.payment.mode">
             <field name="name">eBill</field>
-            <field name="company_id" ref="base.main_company"/>
+            <field name="company_id" ref="base.main_company" />
             <field name="bank_account_link">variable</field>
-            <field name="payment_method_id" ref="account.account_payment_method_manual_in"/>
-            <field name="active" eval="True"/>
+            <field
+        name="payment_method_id"
+        ref="account.account_payment_method_manual_in"
+      />
+            <field name="active" eval="True" />
         </record>
 
-        <record id="account_payment_method_ebill" model="account.payment.method">
+        <record
+      id="account_payment_method_ebill"
+      model="account.payment.method"
+    >
             <field name="name">eBill</field>
             <field name="code">ebill</field>
             <field name="payment_type">inbound</field>

--- a/my_compassion_switzerland/static/src/js/my2_new_sponsorship_wizard_ebill.js
+++ b/my_compassion_switzerland/static/src/js/my2_new_sponsorship_wizard_ebill.js
@@ -134,10 +134,10 @@ document.addEventListener("DOMContentLoaded", function (event) {
               "The clicked button is missing a 'data-action' attribute."
             );
             return;
-          } else if (action === "/ebill/validate") {
+          } else if (action === "/ebill/subscribe") {
             params.email =
               this.$("#email_input").val() ?? this.$("#email").val();
-          } else if (action === "/ebill/confirm") {
+          } else if (action === "/ebill/validate") {
             params.validation_code = this.$("#validation_code_input").val();
             params.token = this.$("#token").val();
             params.email = this.$("#email").val();

--- a/my_compassion_switzerland/static/src/js/my2_new_sponsorship_wizard_ebill.js
+++ b/my_compassion_switzerland/static/src/js/my2_new_sponsorship_wizard_ebill.js
@@ -1,0 +1,169 @@
+/*
+ * Extends the existing NewSponsorshipWizard with eBill functionality.
+ * Detects when the user selects "eBill" as a payment method, shows the
+ * eBill setup container, and disables the finish button until setup
+ * is completed successfully.
+ *
+ * The script communicates with backend endpoints:
+ *  - /ebill/current-user/contract  => checks if a contract exists
+ *  - /ebill/subscribe              =>  starts the eBill setup flow
+ *  - /ebill/validate, /ebill/confirm => validate and confirm steps
+ *
+ * ------------------------------------------------------------------------------- */
+document.addEventListener("DOMContentLoaded", function (event) {
+    odoo.define("my_compassion_switzerland.new_sponsorship_wizard_ebill", function (require) {
+        "use strict";
+
+        var publicWidget = require("web.public.widget");
+        var rpc = require("web.rpc");
+        var ajax = require("web.ajax");
+
+        var NewSponsorshipWizard = publicWidget.registry.NewSponsorshipWizard;
+
+        if (!NewSponsorshipWizard) {
+            return;
+        }
+
+        NewSponsorshipWizard.include({
+            events: _.extend({}, NewSponsorshipWizard.prototype.events, {
+                "change #payment_method": "_onPaymentMethodChange",
+                "click #start_ebill_workflow_btn": "_onStartEbillWorkflow",
+                "click #ebill_content_container button[type='submit']": "_onEbillFormSubmit",
+                "click #ebill_content_container a[type='submit']": "_onEbillFormSubmit",
+            }),
+
+            _eBill: { has_contract: false, partner: null, contract: null },
+
+            /**
+            * @override
+            */
+            start: function () {
+                this._super.apply(this, arguments);
+
+                this._onPaymentMethodChange();
+                this._initEbillState();
+            },
+
+            /**
+             * Checks if user has already an ebill contract.
+             * @private
+             */
+            _initEbillState: function () {
+                return rpc
+                    .query({
+                        route: "/ebill/current-user/contract",
+                        params: {},
+                    })
+                    .then((eBillInfoOfCurrentUser) => {
+                        this._eBill = eBillInfoOfCurrentUser;
+                    })
+                    .catch((err) => {
+                        console.warn("Could not check existing eBill contract:", err);
+                    });
+            },
+
+            /**
+             * Handles the change event on the payment method dropdown.
+             * @private
+             */
+            _onPaymentMethodChange: function () {
+                const selectedText = this.$("#payment_method option:selected").text();
+                const isEBill = selectedText.includes("eBill");
+
+                console.log("Payment method changed. isEBill =", isEBill);
+                if (isEBill) {
+                    if (!this._eBill.has_contract) {
+                        this.$("#ebill_setup_container").toggleClass("d-none", false);
+                        this.$("#finish_button").prop("disabled", true);
+                    }
+                } else {
+                    this.$("#ebill_setup_container").toggleClass("d-none", true);
+                    this.$("#finish_button").prop("disabled", false);
+                }
+            },
+
+            /**
+             * Starts the E-Bill workflow when the "Set up" button is clicked.
+             * @private
+             * @param {Event} ev
+             */
+            _onStartEbillWorkflow: function (ev) {
+                ev.preventDefault();
+
+                const params = {
+                    is_integrated: true,
+                    email: this._eBill.partner?.email,
+                };
+
+                ajax.post("/ebill/subscribe", params)
+                    .then((html) => {
+                        this.$("#ebill_setup_container").show();
+                        html = this._applyMy2StylesToEbill(html);
+                        this.$("#ebill_content_container").html(html);
+                        this.$("#finish_button").prop("disabled", true);
+                    })
+                    .catch(console.error);
+            },
+
+            /**
+             * Intercepts form submissions inside the E-Bill modal and handles them via rpc.
+             * @private
+             * @param {Event} ev
+             */
+            _onEbillFormSubmit: function (ev) {
+                const form = ev.delegateTarget;
+                const noValidationNeeded = $(ev.currentTarget).is("[formnovalidate]");
+
+                if (!form.checkValidity() && !noValidationNeeded) {
+                    form.reportValidity();
+                    return;
+                }
+
+                ev.preventDefault();
+                ev.stopPropagation();
+
+                const action = ev.currentTarget.dataset.action;
+
+                const params = {
+                    is_integrated: true,
+                };
+
+                if (!action) {
+                    console.error("The clicked button is missing a 'data-action' attribute.");
+                    return;
+                } else if (action === "/ebill/validate") {
+                    params.email = this.$("#email_input").val() ?? this.$("#email").val();
+                } else if (action === "/ebill/confirm") {
+                    params.validation_code = this.$("#validation_code_input").val();
+                    params.token = this.$("#token").val();
+                    params.email = this.$("#email").val();
+                }
+
+                ajax.post(action, params)
+                    .then((html) => {
+                        html = this._applyMy2StylesToEbill(html);
+                        this.$("#ebill_content_container").html(html);
+                        const doneSuccessfully = this.$("#ebill_content_container #ebill-success-marker").length > 0;
+                        if (doneSuccessfully) {
+                            this.$("#finish_button").prop("disabled", false);
+                        }
+                    })
+                    .catch(console.error);
+            },
+            /**
+             * Applies Compassion theme styles to the eBill HTML.
+             * @private
+             * @param {string} html The original HTML.
+             * @returns {string} The styled HTML.
+             */
+             _applyMy2StylesToEbill: function (html) {
+                if (!html) {
+                    return "";
+                }
+                return html.replace("btn btn-primary", "btn btn--compact-filled btn--radius-pill bg-core-blue text-pure-white")
+                           .replace("btn btn-secondary", "btn btn--compact-filled btn--radius-pill bg-low-yellow text-black")
+                           .replace("alert alert-danger", "alert alert-danger text-black");
+            },
+        });
+    });
+});

--- a/my_compassion_switzerland/static/src/js/my2_new_sponsorship_wizard_ebill.js
+++ b/my_compassion_switzerland/static/src/js/my2_new_sponsorship_wizard_ebill.js
@@ -92,7 +92,7 @@ document.addEventListener("DOMContentLoaded", function (event) {
 
           const params = {
             is_integrated: true,
-            email: this._eBill.partner?.email,
+            email: this._eBill.partner?.email || "",
           };
 
           ajax

--- a/my_compassion_switzerland/static/src/js/my2_new_sponsorship_wizard_ebill.js
+++ b/my_compassion_switzerland/static/src/js/my2_new_sponsorship_wizard_ebill.js
@@ -41,10 +41,8 @@ document.addEventListener("DOMContentLoaded", function (event) {
         /**
          * @override
          */
-        start: function () {
+        start: async function () {
           this._super.apply(this, arguments);
-
-          this._onPaymentMethodChange();
           this._initEbillState();
         },
 
@@ -60,6 +58,7 @@ document.addEventListener("DOMContentLoaded", function (event) {
             })
             .then((eBillInfoOfCurrentUser) => {
               this._eBill = eBillInfoOfCurrentUser;
+              this._onPaymentMethodChange();
             })
             .catch((err) => {
               console.warn("Could not check existing eBill contract:", err);
@@ -74,12 +73,9 @@ document.addEventListener("DOMContentLoaded", function (event) {
           const selectedText = this.$("#payment_method option:selected").text();
           const isEBill = selectedText.includes("eBill");
 
-          console.log("Payment method changed. isEBill =", isEBill);
-          if (isEBill) {
-            if (!this._eBill.has_contract) {
-              this.$("#ebill_setup_container").toggleClass("d-none", false);
-              this.$("#finish_button").prop("disabled", true);
-            }
+          if (isEBill && !this._eBill.has_contract) {
+            this.$("#ebill_setup_container").toggleClass("d-none", false);
+            this.$("#finish_button").prop("disabled", true);
           } else {
             this.$("#ebill_setup_container").toggleClass("d-none", true);
             this.$("#finish_button").prop("disabled", false);
@@ -116,11 +112,11 @@ document.addEventListener("DOMContentLoaded", function (event) {
          * @param {Event} ev
          */
         _onEbillFormSubmit: function (ev) {
-          const form = ev.delegateTarget;
+          const form = $(ev.currentTarget).closest("form");
           const noValidationNeeded = $(ev.currentTarget).is("[formnovalidate]");
 
-          if (!form.checkValidity() && !noValidationNeeded) {
-            form.reportValidity();
+          if (form.length && !form[0].checkValidity() && !noValidationNeeded) {
+            form[0].reportValidity();
             return;
           }
 

--- a/my_compassion_switzerland/static/src/js/my2_new_sponsorship_wizard_ebill.js
+++ b/my_compassion_switzerland/static/src/js/my2_new_sponsorship_wizard_ebill.js
@@ -11,159 +11,178 @@
  *
  * ------------------------------------------------------------------------------- */
 document.addEventListener("DOMContentLoaded", function (event) {
-    odoo.define("my_compassion_switzerland.new_sponsorship_wizard_ebill", function (require) {
-        "use strict";
+  odoo.define(
+    "my_compassion_switzerland.new_sponsorship_wizard_ebill",
+    function (require) {
+      "use strict";
 
-        var publicWidget = require("web.public.widget");
-        var rpc = require("web.rpc");
-        var ajax = require("web.ajax");
+      var publicWidget = require("web.public.widget");
+      var rpc = require("web.rpc");
+      var ajax = require("web.ajax");
 
-        var NewSponsorshipWizard = publicWidget.registry.NewSponsorshipWizard;
+      var NewSponsorshipWizard = publicWidget.registry.NewSponsorshipWizard;
 
-        if (!NewSponsorshipWizard) {
+      if (!NewSponsorshipWizard) {
+        return;
+      }
+
+      NewSponsorshipWizard.include({
+        events: _.extend({}, NewSponsorshipWizard.prototype.events, {
+          "change #payment_method": "_onPaymentMethodChange",
+          "click #start_ebill_workflow_btn": "_onStartEbillWorkflow",
+          "click #ebill_content_container button[type='submit']":
+            "_onEbillFormSubmit",
+          "click #ebill_content_container a[type='submit']":
+            "_onEbillFormSubmit",
+        }),
+
+        _eBill: { has_contract: false, partner: null, contract: null },
+
+        /**
+         * @override
+         */
+        start: function () {
+          this._super.apply(this, arguments);
+
+          this._onPaymentMethodChange();
+          this._initEbillState();
+        },
+
+        /**
+         * Checks if user has already an ebill contract.
+         * @private
+         */
+        _initEbillState: function () {
+          return rpc
+            .query({
+              route: "/ebill/current-user/contract",
+              params: {},
+            })
+            .then((eBillInfoOfCurrentUser) => {
+              this._eBill = eBillInfoOfCurrentUser;
+            })
+            .catch((err) => {
+              console.warn("Could not check existing eBill contract:", err);
+            });
+        },
+
+        /**
+         * Handles the change event on the payment method dropdown.
+         * @private
+         */
+        _onPaymentMethodChange: function () {
+          const selectedText = this.$("#payment_method option:selected").text();
+          const isEBill = selectedText.includes("eBill");
+
+          console.log("Payment method changed. isEBill =", isEBill);
+          if (isEBill) {
+            if (!this._eBill.has_contract) {
+              this.$("#ebill_setup_container").toggleClass("d-none", false);
+              this.$("#finish_button").prop("disabled", true);
+            }
+          } else {
+            this.$("#ebill_setup_container").toggleClass("d-none", true);
+            this.$("#finish_button").prop("disabled", false);
+          }
+        },
+
+        /**
+         * Starts the E-Bill workflow when the "Set up" button is clicked.
+         * @private
+         * @param {Event} ev
+         */
+        _onStartEbillWorkflow: function (ev) {
+          ev.preventDefault();
+
+          const params = {
+            is_integrated: true,
+            email: this._eBill.partner?.email,
+          };
+
+          ajax
+            .post("/ebill/subscribe", params)
+            .then((html) => {
+              this.$("#ebill_setup_container").show();
+              html = this._applyMy2StylesToEbill(html);
+              this.$("#ebill_content_container").html(html);
+              this.$("#finish_button").prop("disabled", true);
+            })
+            .catch(console.error);
+        },
+
+        /**
+         * Intercepts form submissions inside the E-Bill modal and handles them via rpc.
+         * @private
+         * @param {Event} ev
+         */
+        _onEbillFormSubmit: function (ev) {
+          const form = ev.delegateTarget;
+          const noValidationNeeded = $(ev.currentTarget).is("[formnovalidate]");
+
+          if (!form.checkValidity() && !noValidationNeeded) {
+            form.reportValidity();
             return;
-        }
+          }
 
-        NewSponsorshipWizard.include({
-            events: _.extend({}, NewSponsorshipWizard.prototype.events, {
-                "change #payment_method": "_onPaymentMethodChange",
-                "click #start_ebill_workflow_btn": "_onStartEbillWorkflow",
-                "click #ebill_content_container button[type='submit']": "_onEbillFormSubmit",
-                "click #ebill_content_container a[type='submit']": "_onEbillFormSubmit",
-            }),
+          ev.preventDefault();
+          ev.stopPropagation();
 
-            _eBill: { has_contract: false, partner: null, contract: null },
+          const action = ev.currentTarget.dataset.action;
 
-            /**
-            * @override
-            */
-            start: function () {
-                this._super.apply(this, arguments);
+          const params = {
+            is_integrated: true,
+          };
 
-                this._onPaymentMethodChange();
-                this._initEbillState();
-            },
+          if (!action) {
+            console.error(
+              "The clicked button is missing a 'data-action' attribute."
+            );
+            return;
+          } else if (action === "/ebill/validate") {
+            params.email =
+              this.$("#email_input").val() ?? this.$("#email").val();
+          } else if (action === "/ebill/confirm") {
+            params.validation_code = this.$("#validation_code_input").val();
+            params.token = this.$("#token").val();
+            params.email = this.$("#email").val();
+          }
 
-            /**
-             * Checks if user has already an ebill contract.
-             * @private
-             */
-            _initEbillState: function () {
-                return rpc
-                    .query({
-                        route: "/ebill/current-user/contract",
-                        params: {},
-                    })
-                    .then((eBillInfoOfCurrentUser) => {
-                        this._eBill = eBillInfoOfCurrentUser;
-                    })
-                    .catch((err) => {
-                        console.warn("Could not check existing eBill contract:", err);
-                    });
-            },
-
-            /**
-             * Handles the change event on the payment method dropdown.
-             * @private
-             */
-            _onPaymentMethodChange: function () {
-                const selectedText = this.$("#payment_method option:selected").text();
-                const isEBill = selectedText.includes("eBill");
-
-                console.log("Payment method changed. isEBill =", isEBill);
-                if (isEBill) {
-                    if (!this._eBill.has_contract) {
-                        this.$("#ebill_setup_container").toggleClass("d-none", false);
-                        this.$("#finish_button").prop("disabled", true);
-                    }
-                } else {
-                    this.$("#ebill_setup_container").toggleClass("d-none", true);
-                    this.$("#finish_button").prop("disabled", false);
-                }
-            },
-
-            /**
-             * Starts the E-Bill workflow when the "Set up" button is clicked.
-             * @private
-             * @param {Event} ev
-             */
-            _onStartEbillWorkflow: function (ev) {
-                ev.preventDefault();
-
-                const params = {
-                    is_integrated: true,
-                    email: this._eBill.partner?.email,
-                };
-
-                ajax.post("/ebill/subscribe", params)
-                    .then((html) => {
-                        this.$("#ebill_setup_container").show();
-                        html = this._applyMy2StylesToEbill(html);
-                        this.$("#ebill_content_container").html(html);
-                        this.$("#finish_button").prop("disabled", true);
-                    })
-                    .catch(console.error);
-            },
-
-            /**
-             * Intercepts form submissions inside the E-Bill modal and handles them via rpc.
-             * @private
-             * @param {Event} ev
-             */
-            _onEbillFormSubmit: function (ev) {
-                const form = ev.delegateTarget;
-                const noValidationNeeded = $(ev.currentTarget).is("[formnovalidate]");
-
-                if (!form.checkValidity() && !noValidationNeeded) {
-                    form.reportValidity();
-                    return;
-                }
-
-                ev.preventDefault();
-                ev.stopPropagation();
-
-                const action = ev.currentTarget.dataset.action;
-
-                const params = {
-                    is_integrated: true,
-                };
-
-                if (!action) {
-                    console.error("The clicked button is missing a 'data-action' attribute.");
-                    return;
-                } else if (action === "/ebill/validate") {
-                    params.email = this.$("#email_input").val() ?? this.$("#email").val();
-                } else if (action === "/ebill/confirm") {
-                    params.validation_code = this.$("#validation_code_input").val();
-                    params.token = this.$("#token").val();
-                    params.email = this.$("#email").val();
-                }
-
-                ajax.post(action, params)
-                    .then((html) => {
-                        html = this._applyMy2StylesToEbill(html);
-                        this.$("#ebill_content_container").html(html);
-                        const doneSuccessfully = this.$("#ebill_content_container #ebill-success-marker").length > 0;
-                        if (doneSuccessfully) {
-                            this.$("#finish_button").prop("disabled", false);
-                        }
-                    })
-                    .catch(console.error);
-            },
-            /**
-             * Applies Compassion theme styles to the eBill HTML.
-             * @private
-             * @param {string} html The original HTML.
-             * @returns {string} The styled HTML.
-             */
-             _applyMy2StylesToEbill: function (html) {
-                if (!html) {
-                    return "";
-                }
-                return html.replace("btn btn-primary", "btn btn--compact-filled btn--radius-pill bg-core-blue text-pure-white")
-                           .replace("btn btn-secondary", "btn btn--compact-filled btn--radius-pill bg-low-yellow text-black")
-                           .replace("alert alert-danger", "alert alert-danger text-black");
-            },
-        });
-    });
+          ajax
+            .post(action, params)
+            .then((html) => {
+              html = this._applyMy2StylesToEbill(html);
+              this.$("#ebill_content_container").html(html);
+              const doneSuccessfully =
+                this.$("#ebill_content_container #ebill-success-marker")
+                  .length > 0;
+              if (doneSuccessfully) {
+                this.$("#finish_button").prop("disabled", false);
+              }
+            })
+            .catch(console.error);
+        },
+        /**
+         * Applies Compassion theme styles to the eBill HTML.
+         * @private
+         * @param {string} html The original HTML.
+         * @returns {string} The styled HTML.
+         */
+        _applyMy2StylesToEbill: function (html) {
+          if (!html) {
+            return "";
+          }
+          return html
+            .replace(
+              "btn btn-primary",
+              "btn btn--compact-filled btn--radius-pill bg-core-blue text-pure-white"
+            )
+            .replace(
+              "btn btn-secondary",
+              "btn btn--compact-filled btn--radius-pill bg-low-yellow text-black"
+            )
+            .replace("alert alert-danger", "alert alert-danger text-black");
+        },
+      });
+    }
+  );
 });

--- a/my_compassion_switzerland/templates/assets.xml
+++ b/my_compassion_switzerland/templates/assets.xml
@@ -1,11 +1,18 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8" ?>
 <odoo>
-    <template id="assets_frontend_ebill_wizard_fix"
-              inherit_id="my_compassion.my2_new_sponsorship_wizard_page">
+    <template
+    id="assets_frontend_ebill_wizard_fix"
+    inherit_id="my_compassion.my2_new_sponsorship_wizard_page"
+  >
 
-        <xpath expr="//script[@src='/my_compassion/static/src/js/my2_new_sponsorship_wizard.js']" position="after">
-            <script type="text/javascript"
-                    src="/my_compassion_switzerland/static/src/js/my2_new_sponsorship_wizard_ebill.js"/>
+        <xpath
+      expr="//script[@src='/my_compassion/static/src/js/my2_new_sponsorship_wizard.js']"
+      position="after"
+    >
+            <script
+        type="text/javascript"
+        src="/my_compassion_switzerland/static/src/js/my2_new_sponsorship_wizard_ebill.js"
+      />
         </xpath>
     </template>
 </odoo>

--- a/my_compassion_switzerland/templates/assets.xml
+++ b/my_compassion_switzerland/templates/assets.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="assets_frontend_ebill_wizard_fix"
+              inherit_id="my_compassion.my2_new_sponsorship_wizard_page">
+
+        <xpath expr="//script[@src='/my_compassion/static/src/js/my2_new_sponsorship_wizard.js']" position="after">
+            <script type="text/javascript"
+                    src="/my_compassion_switzerland/static/src/js/my2_new_sponsorship_wizard_ebill.js"/>
+        </xpath>
+    </template>
+</odoo>

--- a/my_compassion_switzerland/templates/my2_new_sponsorship_wizard_ebill.xml
+++ b/my_compassion_switzerland/templates/my2_new_sponsorship_wizard_ebill.xml
@@ -14,10 +14,16 @@ Page: My Compassion 2 – New Sponsorship Wizard - Inject eBill Container during
     - Provides DOM hooks: #ebill_setup_container, #ebill_content_container, #start_ebill_workflow_btn.
 -->
 <odoo>
-  <template id="inject_ebill_container_during_payment_selection" inherit_id="my_compassion.my2_new_sponsorship_wizard_payment_method" name="Inject eBill container during payment selection">
+  <template
+    id="inject_ebill_container_during_payment_selection"
+    inherit_id="my_compassion.my2_new_sponsorship_wizard_payment_method"
+    name="Inject eBill container during payment selection"
+  >
         <xpath
-          expr="//t[@t-call='theme_compassion_2025.FormFieldComponent']
-                   [.//t[@t-set='input_id' and @t-value=&quot;'payment_method'&quot;]]" position="after">
+      expr="//t[@t-call='theme_compassion_2025.FormFieldComponent']
+                   [.//t[@t-set='input_id' and @t-value=&quot;'payment_method'&quot;]]"
+      position="after"
+    >
 
       <div id="ebill_setup_container" class="my-3 d-none">
         <div id="ebill_content_container" class="p-4 bg-high-yellow rounded-lg">
@@ -27,9 +33,11 @@ Page: My Compassion 2 – New Sponsorship Wizard - Inject eBill Container during
               You selected E-Bill. To continue, please set up your E-Bill connection with Compassion.
             </p>
             <div class="d-flex justify-content-end">
-              <button type="button"
-                      class="btn btn--compact-filled btn--radius-pill bg-core-blue text-pure-white"
-                      id="start_ebill_workflow_btn">
+              <button
+                type="button"
+                class="btn btn--compact-filled btn--radius-pill bg-core-blue text-pure-white"
+                id="start_ebill_workflow_btn"
+              >
                 Set up E-Bill Now
               </button>
             </div>

--- a/my_compassion_switzerland/templates/my2_new_sponsorship_wizard_ebill.xml
+++ b/my_compassion_switzerland/templates/my2_new_sponsorship_wizard_ebill.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+Page: My Compassion 2 – New Sponsorship Wizard - Inject eBill Container during Payment Selection
+
+    Description:
+    Injects the eBill setup container into the payment step of the wizard.
+    The block is shown when the user selects "eBill" as payment method.
+
+    Target:
+    - my_compassion.my2_new_sponsorship_wizard_payment_method
+
+    Notes:
+    - Replaces the <div id="ebill_hook"> anchor in the base template.
+    - Provides DOM hooks: #ebill_setup_container, #ebill_content_container, #start_ebill_workflow_btn.
+-->
+<odoo>
+  <template id="inject_ebill_container_during_payment_selection" inherit_id="my_compassion.my2_new_sponsorship_wizard_payment_method" name="Inject eBill container during payment selection">
+        <xpath
+          expr="//t[@t-call='theme_compassion_2025.FormFieldComponent']
+                   [.//t[@t-set='input_id' and @t-value=&quot;'payment_method'&quot;]]" position="after">
+
+      <div id="ebill_setup_container" class="my-3 d-none">
+        <div id="ebill_content_container" class="p-4 bg-high-yellow rounded-lg">
+          <div class="my-2">
+            <h1 class="mb-4 mt-0">E-Bill</h1>
+            <p>
+              You selected E-Bill. To continue, please set up your E-Bill connection with Compassion.
+            </p>
+            <div class="d-flex justify-content-end">
+              <button type="button"
+                      class="btn btn--compact-filled btn--radius-pill bg-core-blue text-pure-white"
+                      id="start_ebill_workflow_btn">
+                Set up E-Bill Now
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </xpath>
+  </template>
+</odoo>


### PR DESCRIPTION
**_Ticket [T2679](https://erp.compassion.ch/web#id=3271&action=521&active_id=901&model=project.task&view_type=form&cids=1&menu_id=2029)_**

**Needs https://github.com/CompassionCH/l10n-switzerland/pull/72 & https://github.com/CompassionCH/compassion-website/pull/176**

This PR integrates the eBill workflow into the New Sponsorship Wizard. Since it is a Compassion Switzerland–specific feature, it is implemented in this repository rather than directly in my_compassion.
It enables users to directly set up, validate, and confirm their eBill connection during the sponsorship process to ensure a seamless and automated payment setup experience.

This is included in this ebill workflow:

- Enter email address (if not already known - only necessary if no user is logged in) 
- Request validation code
- Resend Code - if code was wrong
- Enter code and confirm registration
- Success

## **Process (Step-by-Step)**
### **1. No eBill connection with logged in user (Finish disabled)**

When the user does not yet have an active eBill contract, the Finish button is disabled until the setup is completed.

<img width="962" height="1013" alt="image" src="https://github.com/user-attachments/assets/e4ddd8f9-5e40-448c-97dc-8dc7fb539171" />

### **2a. eBill setup workflow**

The user can start the eBill registration process by clicking “Set up eBill”, which opens the guided workflow.

<img width="971" height="1064" alt="image" src="https://github.com/user-attachments/assets/2490fe41-d2d4-45ec-bbc0-4ddd897de514" />

### **2b. Invalid validation code**

If the entered code is incorrect, a red alert appears:

“Validation failed. Please verify the code or check if an eBill is possible for this email.“

The user can then resend the validation code to return to the normal flow.

<img width="991" height="1153" alt="image" src="https://github.com/user-attachments/assets/cd4f27c4-2bf6-4663-99ed-94c4fb6dfff9" /> 

### **2c. After resend**

<img width="971" height="1064" alt="image" src="https://github.com/user-attachments/assets/2490fe41-d2d4-45ec-bbc0-4ddd897de514" />

### **3. Successful eBill registration**

After a successful confirmation, a success message is displayed and the Finish button becomes active.

<img width="959" height="915" alt="image" src="https://github.com/user-attachments/assets/a690a02f-081b-48cc-b028-d7031902da8f" />

### **4. Completing the sponsorship**

The user can now complete the sponsorship process with eBill as the payment method. (as before)

<img width="894" height="971" alt="image" src="https://github.com/user-attachments/assets/9e9b1ee3-8b95-4f6f-93b2-aaf0df19153f" />

### **Existing eBill connection with current user**

If the user already has an active eBill contract, the wizard skips the setup workflow.
The user can directly select eBill and finish the wizard without any additional input.
Optionally, we could display an info message such as:

“You already have an active eBill connection — you’re good to go!”

<img width="937" height="792" alt="image" src="https://github.com/user-attachments/assets/672a37bf-6c79-4b65-bccc-df3ef4715355" />

### **Without logged in user**

If no user is logged in, the eBill setup requires the user to enter their email upfront (before starting the validation steps).
This happens between step 1 and 2 above.

<img width="991" height="1017" alt="image" src="https://github.com/user-attachments/assets/9b1a3565-58ce-443f-be10-c25419bcf080" />


