### PR TITLE
[T2517] FIX remove advertising for odoo mobile app from hr module

### DIFF
--- a/hr_switzerland/views/hr_expense_custom.xml
+++ b/hr_switzerland/views/hr_expense_custom.xml
@@ -8,9 +8,29 @@
         <field name="arch" type="xml">
             <field name="product_id" position="attributes">
                 <attribute
-          name="options"
-        >{'create_edit':false, 'create': false}</attribute>
+                        name="options"
+                >{'create_edit':false, 'create': false}</attribute>
             </field>
+        </field>
+    </record>
+    <record id="hr_expense.hr_expense_actions_my_unsubmitted" model="ir.actions.act_window">
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                Create a new expense
+            </p>
+            <p>
+                Record expenses to be reimbursed to employees.
+            </p>
+        </field>
+    </record>
+    <record id="hr_expense.hr_expense_actions_my_all" model="ir.actions.act_window">
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                Create a new expense
+            </p>
+            <p>
+                Record expenses to be reimbursed to employees.
+            </p>
         </field>
     </record>
 </odoo>

--- a/hr_switzerland/views/hr_expense_custom.xml
+++ b/hr_switzerland/views/hr_expense_custom.xml
@@ -13,17 +13,20 @@
             </field>
         </field>
     </record>
+    <template id="hr_expense_empty_state_help">
+        <p class="o_view_nocontent_smiling_face">
+            Create a new expense
+        </p>
+        <p>
+            Record expenses to be reimbursed to employees.
+        </p>
+    </template>
     <record
     id="hr_expense.hr_expense_actions_my_unsubmitted"
     model="ir.actions.act_window"
   >
         <field name="help" type="html">
-            <p class="o_view_nocontent_smiling_face">
-                Create a new expense
-            </p>
-            <p>
-                Record expenses to be reimbursed to employees.
-            </p>
+            <t t-call="hr_switzerland.hr_expense_empty_state_help" />
         </field>
     </record>
     <record
@@ -31,12 +34,7 @@
     model="ir.actions.act_window"
   >
         <field name="help" type="html">
-            <p class="o_view_nocontent_smiling_face">
-                Create a new expense
-            </p>
-            <p>
-                Record expenses to be reimbursed to employees.
-            </p>
+            <t t-call="hr_switzerland.hr_expense_empty_state_help" />
         </field>
     </record>
 </odoo>

--- a/hr_switzerland/views/hr_expense_custom.xml
+++ b/hr_switzerland/views/hr_expense_custom.xml
@@ -8,12 +8,15 @@
         <field name="arch" type="xml">
             <field name="product_id" position="attributes">
                 <attribute
-                        name="options"
-                >{'create_edit':false, 'create': false}</attribute>
+          name="options"
+        >{'create_edit':false, 'create': false}</attribute>
             </field>
         </field>
     </record>
-    <record id="hr_expense.hr_expense_actions_my_unsubmitted" model="ir.actions.act_window">
+    <record
+    id="hr_expense.hr_expense_actions_my_unsubmitted"
+    model="ir.actions.act_window"
+  >
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
                 Create a new expense
@@ -23,7 +26,10 @@
             </p>
         </field>
     </record>
-    <record id="hr_expense.hr_expense_actions_my_all" model="ir.actions.act_window">
+    <record
+    id="hr_expense.hr_expense_actions_my_all"
+    model="ir.actions.act_window"
+  >
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
                 Create a new expense


### PR DESCRIPTION
### Problem:
Our internal users accessing the Expense application are seeing an Odoo Enterprise mobile app advertisement in the empty state views. Since this mobile feature is not available to us in the Odoo Community Edition (CE) environment, this banner is misleading and causes user confusion.

### Solution:
In this PR I override theses unwanted records in `hr_switzerland` module. These changes remove the mobile app promotion and replaces it with a helpful message guiding the user.

<img width="3837" height="1360" alt="image" src="https://github.com/user-attachments/assets/9a296d10-151e-47ad-a0ca-6a4b05f349fe" />
