### PR TITLE
T2795 dont send b2s intro letter not working

### DIFF
--- a/partner_communication_switzerland/__manifest__.py
+++ b/partner_communication_switzerland/__manifest__.py
@@ -46,6 +46,7 @@
         "recurring_contract",  # compassion-accounting
         "survival_sponsorship_compassion",
         "link_tracker",
+        "partner_communication_compassion",
     ],
     "external_dependencies": {
         "python": [

--- a/partner_communication_switzerland/views/contract_view.xml
+++ b/partner_communication_switzerland/views/contract_view.xml
@@ -5,52 +5,53 @@
     The licence is in the file __manifest__.py
 -->
 <odoo>
-     <record id="view_recurring_contract_form" model="ir.ui.view">
+    <record id="view_recurring_contract_form" model="ir.ui.view">
         <field name="name">recurring.contract.form</field>
         <field name="model">recurring.contract</field>
         <field
-      name="inherit_id"
-      ref="sponsorship_switzerland.view_recurring_contract_form_compassion"
-    />
-        <field name="arch" type="xml">
-            <xpath expr="//field[@name='origin_id']" position="after">
-                <field name="origin_type" invisible="1" />
-                <field name="origin_name" invisible="1" />
-                <!-- this field is there because the type of origin_id couldn't be reached with the xml file -->
-                <field
-          name="send_introduction_letter"
-          attrs="{'invisible':[('type', 'not in', ['S','SC','SWP'])]}"
+                name="inherit_id"
+                ref="sponsorship_switzerland.view_recurring_contract_form_compassion"
         />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='send_introduction_letter']" position="replace">
+                <field
+                        name="send_introduction_letter"
+                        attrs="{'invisible':[('type', 'not in', ['S','SC','SWP'])]}"
+                />
+            </xpath>
+            <xpath expr="//field[@name='origin_id']" position="after">
+                <field name="origin_type" invisible="1"/>
+                <field name="origin_name" invisible="1"/>
             </xpath>
             <xpath expr="//field[@name='activation_date']" position="before">
-                <field name="onboarding_start_date" />
+                <field name="onboarding_start_date"/>
             </xpath>
             <header>
-                <field name="sub_proposal_date" invisible="1" />
+                <field name="sub_proposal_date" invisible="1"/>
                 <button
-          name="cancel_sub_validation"
-          type="object"
-          string="Cancel SUB validation"
-          attrs="{'invisible': [('sub_proposal_date', '=', False)]}"
-        />
+                        name="cancel_sub_validation"
+                        type="object"
+                        string="Cancel SUB validation"
+                        attrs="{'invisible': [('sub_proposal_date', '=', False)]}"
+                />
             </header>
         </field>
-     </record>
+    </record>
 
     <record id="sub_validation_filter_view" model="ir.ui.view">
         <field name="name">sub validation filter</field>
         <field name="model">recurring.contract</field>
         <field
-      name="inherit_id"
-      ref="sponsorship_compassion.view_recurring_contract_filter_graph"
-    />
+                name="inherit_id"
+                ref="sponsorship_compassion.view_recurring_contract_filter_graph"
+        />
         <field name="arch" type="xml">
             <search>
                 <filter
-          name="sub_validation"
-          string="SUB validation"
-          domain="[('sub_proposal_date', '!=', False),('state','=','draft')]"
-        />
+                        name="sub_validation"
+                        string="SUB validation"
+                        domain="[('sub_proposal_date', '!=', False),('state','=','draft')]"
+                />
             </search>
         </field>
     </record>

--- a/partner_communication_switzerland/views/contract_view.xml
+++ b/partner_communication_switzerland/views/contract_view.xml
@@ -9,31 +9,34 @@
         <field name="name">recurring.contract.form</field>
         <field name="model">recurring.contract</field>
         <field
-                name="inherit_id"
-                ref="sponsorship_switzerland.view_recurring_contract_form_compassion"
-        />
+      name="inherit_id"
+      ref="sponsorship_switzerland.view_recurring_contract_form_compassion"
+    />
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='send_introduction_letter']" position="replace">
+            <xpath
+        expr="//field[@name='send_introduction_letter']"
+        position="replace"
+      >
                 <field
-                        name="send_introduction_letter"
-                        attrs="{'invisible':[('type', 'not in', ['S','SC','SWP'])]}"
-                />
+          name="send_introduction_letter"
+          attrs="{'invisible':[('type', 'not in', ['S','SC','SWP'])]}"
+        />
             </xpath>
             <xpath expr="//field[@name='origin_id']" position="after">
-                <field name="origin_type" invisible="1"/>
-                <field name="origin_name" invisible="1"/>
+                <field name="origin_type" invisible="1" />
+                <field name="origin_name" invisible="1" />
             </xpath>
             <xpath expr="//field[@name='activation_date']" position="before">
-                <field name="onboarding_start_date"/>
+                <field name="onboarding_start_date" />
             </xpath>
             <header>
-                <field name="sub_proposal_date" invisible="1"/>
+                <field name="sub_proposal_date" invisible="1" />
                 <button
-                        name="cancel_sub_validation"
-                        type="object"
-                        string="Cancel SUB validation"
-                        attrs="{'invisible': [('sub_proposal_date', '=', False)]}"
-                />
+          name="cancel_sub_validation"
+          type="object"
+          string="Cancel SUB validation"
+          attrs="{'invisible': [('sub_proposal_date', '=', False)]}"
+        />
             </header>
         </field>
     </record>
@@ -42,16 +45,16 @@
         <field name="name">sub validation filter</field>
         <field name="model">recurring.contract</field>
         <field
-                name="inherit_id"
-                ref="sponsorship_compassion.view_recurring_contract_filter_graph"
-        />
+      name="inherit_id"
+      ref="sponsorship_compassion.view_recurring_contract_filter_graph"
+    />
         <field name="arch" type="xml">
             <search>
                 <filter
-                        name="sub_validation"
-                        string="SUB validation"
-                        domain="[('sub_proposal_date', '!=', False),('state','=','draft')]"
-                />
+          name="sub_validation"
+          string="SUB validation"
+          domain="[('sub_proposal_date', '!=', False),('state','=','draft')]"
+        />
             </search>
         </field>
     </record>

--- a/partner_communication_switzerland/views/contract_view.xml
+++ b/partner_communication_switzerland/views/contract_view.xml
@@ -8,35 +8,35 @@
     <record id="view_recurring_contract_form" model="ir.ui.view">
         <field name="name">recurring.contract.form</field>
         <field name="model">recurring.contract</field>
-        <field
-      name="inherit_id"
-      ref="sponsorship_switzerland.view_recurring_contract_form_compassion"
-    />
+        <field name="priority" eval="99"/>
+        <field name="inherit_id"
+               ref="sponsorship_switzerland.view_recurring_contract_form_compassion"
+        />
         <field name="arch" type="xml">
             <xpath
-        expr="//field[@name='send_introduction_letter']"
-        position="replace"
-      >
+                    expr="//field[@name='send_introduction_letter']"
+                    position="replace"
+            >
                 <field
-          name="send_introduction_letter"
-          attrs="{'invisible':[('type', 'not in', ['S','SC','SWP'])]}"
-        />
+                        name="send_introduction_letter"
+                        attrs="{'invisible':[('type', 'not in', ['S','SC','SWP'])]}"
+                />
             </xpath>
             <xpath expr="//field[@name='origin_id']" position="after">
-                <field name="origin_type" invisible="1" />
-                <field name="origin_name" invisible="1" />
+                <field name="origin_type" invisible="1"/>
+                <field name="origin_name" invisible="1"/>
             </xpath>
             <xpath expr="//field[@name='activation_date']" position="before">
-                <field name="onboarding_start_date" />
+                <field name="onboarding_start_date"/>
             </xpath>
             <header>
-                <field name="sub_proposal_date" invisible="1" />
+                <field name="sub_proposal_date" invisible="1"/>
                 <button
-          name="cancel_sub_validation"
-          type="object"
-          string="Cancel SUB validation"
-          attrs="{'invisible': [('sub_proposal_date', '=', False)]}"
-        />
+                        name="cancel_sub_validation"
+                        type="object"
+                        string="Cancel SUB validation"
+                        attrs="{'invisible': [('sub_proposal_date', '=', False)]}"
+                />
             </header>
         </field>
     </record>
@@ -45,16 +45,16 @@
         <field name="name">sub validation filter</field>
         <field name="model">recurring.contract</field>
         <field
-      name="inherit_id"
-      ref="sponsorship_compassion.view_recurring_contract_filter_graph"
-    />
+                name="inherit_id"
+                ref="sponsorship_compassion.view_recurring_contract_filter_graph"
+        />
         <field name="arch" type="xml">
             <search>
                 <filter
-          name="sub_validation"
-          string="SUB validation"
-          domain="[('sub_proposal_date', '!=', False),('state','=','draft')]"
-        />
+                        name="sub_validation"
+                        string="SUB validation"
+                        domain="[('sub_proposal_date', '!=', False),('state','=','draft')]"
+                />
             </search>
         </field>
     </record>

--- a/partner_communication_switzerland/views/contract_view.xml
+++ b/partner_communication_switzerland/views/contract_view.xml
@@ -8,35 +8,36 @@
     <record id="view_recurring_contract_form" model="ir.ui.view">
         <field name="name">recurring.contract.form</field>
         <field name="model">recurring.contract</field>
-        <field name="priority" eval="99"/>
-        <field name="inherit_id"
-               ref="sponsorship_switzerland.view_recurring_contract_form_compassion"
-        />
+        <field name="priority" eval="99" />
+        <field
+      name="inherit_id"
+      ref="sponsorship_switzerland.view_recurring_contract_form_compassion"
+    />
         <field name="arch" type="xml">
             <xpath
-                    expr="//field[@name='send_introduction_letter']"
-                    position="replace"
-            >
+        expr="//field[@name='send_introduction_letter']"
+        position="replace"
+      >
                 <field
-                        name="send_introduction_letter"
-                        attrs="{'invisible':[('type', 'not in', ['S','SC','SWP'])]}"
-                />
+          name="send_introduction_letter"
+          attrs="{'invisible':[('type', 'not in', ['S','SC','SWP'])]}"
+        />
             </xpath>
             <xpath expr="//field[@name='origin_id']" position="after">
-                <field name="origin_type" invisible="1"/>
-                <field name="origin_name" invisible="1"/>
+                <field name="origin_type" invisible="1" />
+                <field name="origin_name" invisible="1" />
             </xpath>
             <xpath expr="//field[@name='activation_date']" position="before">
-                <field name="onboarding_start_date"/>
+                <field name="onboarding_start_date" />
             </xpath>
             <header>
-                <field name="sub_proposal_date" invisible="1"/>
+                <field name="sub_proposal_date" invisible="1" />
                 <button
-                        name="cancel_sub_validation"
-                        type="object"
-                        string="Cancel SUB validation"
-                        attrs="{'invisible': [('sub_proposal_date', '=', False)]}"
-                />
+          name="cancel_sub_validation"
+          type="object"
+          string="Cancel SUB validation"
+          attrs="{'invisible': [('sub_proposal_date', '=', False)]}"
+        />
             </header>
         </field>
     </record>
@@ -45,16 +46,16 @@
         <field name="name">sub validation filter</field>
         <field name="model">recurring.contract</field>
         <field
-                name="inherit_id"
-                ref="sponsorship_compassion.view_recurring_contract_filter_graph"
-        />
+      name="inherit_id"
+      ref="sponsorship_compassion.view_recurring_contract_filter_graph"
+    />
         <field name="arch" type="xml">
             <search>
                 <filter
-                        name="sub_validation"
-                        string="SUB validation"
-                        domain="[('sub_proposal_date', '!=', False),('state','=','draft')]"
-                />
+          name="sub_validation"
+          string="SUB validation"
+          domain="[('sub_proposal_date', '!=', False),('state','=','draft')]"
+        />
             </search>
         </field>
     </record>


### PR DESCRIPTION
# FIX: [Odoo View] Duplicate Field Correction in recurring.contract

## Problem Description

A field in the `recurring.contract` form view, specifically `send_introduction_letter`, was displayed twice in the Odoo interface.

This issue originated from the inherited view definitions in the modules `partner_communication_compassion` and `partner_communication_switzerland`.

---

## Justification and Root Cause

1. **Duplicate Field Origin (Logic Conflict)**  
   Tests confirmed that the `send_introduction_letter` field was already present in the parent view.  
   The inheriting module (`partner_communication_switzerland`) inserted the same field again using `position="after"` (after `origin_id`), even though the field already existed.

   **Consequence:**  
   Both the original field and the inserted field were displayed, resulting in a duplicate.

2. **XML ID Conflict**  
   Both modules defined a view with the same identifier (`view_recurring_contract_form`).  
   This caused a conflict where the last-loaded module’s version overrode the other.

---

## The Applied Correction and Impact

1. **Use of `position="replace"`**  
   The insertion instruction was replaced with a `position="replace"` directive targeting the existing field.

   **Action:**  
   Odoo locates the existing `send_introduction_letter` field in the parent view and replaces it with the updated definition.

   **Result:**  
   The duplicate is removed, and the field’s visibility and logic behave correctly.

2. **Dependency and Stability Safeguards**

   - **Separation of Additional Insertions:**  
     Fields such as `origin_type` and `origin_name` were moved to a separate `xpath` insertion block to avoid interfering with the field replacement.

   - **Manifest Dependency:**  
     The module `partner_communication_compassion` was added as a dependency of `partner_communication_switzerland`.  
     This ensures a stable and predictable module loading order in Odoo, maintaining correct view inheritance.

---

### See also
Related PR addressing the same issue : https://github.com/CompassionCH/compassion-modules/pull/2060
