### PR TITLE
[T2787] FIX: The zoom registration case was missing after zoom's crea…

### DIFF
--- a/partner_communication_switzerland/models/res_partner_zoom_attendee.py
+++ b/partner_communication_switzerland/models/res_partner_zoom_attendee.py
@@ -133,6 +133,11 @@ class ZoomAttendee(models.Model):
                     channel="root.partner_communication",
                     identity_key=f"send_zoom_link.{attendee.id}",
                 ).send_communication(ZoomCommunication.LINK.value)
+            else:
+                attendee.with_user(SUPERUSER_ID).with_delay(
+                    channel="root.partner_communication",
+                    identity_key=f"send_zoom_registration.{attendee.id}",
+                ).send_communication(ZoomCommunication.REGISTRATION.value)
             if attendee.optional_message:
                 attendee.notify_user()
         return res


### PR DESCRIPTION
# FIX: [Zoom Onboarding] Initial Communication Flow Correction (REGISTRATION email)

## Problem Description

When a participant was added to a Zoom Onboarding session, the initial communication flow did not work correctly:  
the standard case (sending the **REGISTRATION** email at creation) was not handled.

This fix does **not** address the production bug where an invited participant receives the **LINK** on D-2 instead of the **REMINDER**.

---

## Root Cause Analysis

1. **Standard case not handled in `create`**

   In the `create` method of the `res.partner.zoom.attendee` model, only the situation where `date_send_link` was already set was handled.  
   - If `date_send_link` was not set (normal case) → no email was sent.  
   - If `date_send_link` was set → LINK email was sent (correct only for late registrations or after the Cron).

   **Result:** REGISTRATION was never sent at creation, which is the expected behavior.

2. **Regarding the main production bug (not fixed here)**

   Logs added in `create`, `write`, `send_communication`, `send_reminder_or_link`, and `post_attended` show that:
   - the Cron logic works as expected,
   - our code does not modify the `state` field.

   The transition to `confirmed` therefore happens outside our logic.  
   **If the issue is indeed caused by an external modification of the `state` field**, this would explain why the Cron sends the LINK instead of the REMINDER.  
   The exact source of this change is still unknown.

---

## Applied Fix

1. **Send REGISTRATION by default**

   Added an `else` in `create`:
   - if `date_send_link` is not set → send the **REGISTRATION** email.

   This ensures that participants receive the registration email upon creation.

2. **Clarified communication flow**

   - **REGISTRATION** → automatically sent at creation  
   - **LINK** → sent only if `date_send_link` is set (D-2 or late registration)

---

## Next Steps for the Main Production Bug

The `state` change to `confirmed` is not caused by our code.  
Investigation in the production environment is needed to identify what modifies this field (automation, server action, or manual intervention).
