### PR TITLE
[T2839] - Remove calendar checkbox in communication settings

### DIFF
--- a/partner_communication_switzerland/models/res_partner.py
+++ b/partner_communication_switzerland/models/res_partner.py
@@ -258,7 +258,6 @@ class ResPartner(models.Model):
                 "tax_certificate": (
                     "no" if self.tax_certificate == "no" else "only_email"
                 ),
-                "calendar": False,
                 "sponsorship_anniversary_card": False,
             }
             for _field in [
@@ -274,7 +273,7 @@ class ResPartner(models.Model):
                     vals[_field] = "digital_only"
             self.write(vals)
         else:
-            vals = {"calendar": True, "sponsorship_anniversary_card": True}
+            vals = {"sponsorship_anniversary_card": True}
             for _field in [
                 "global_communication_delivery_preference",
                 "letter_delivery_preference",

--- a/partner_communication_switzerland/views/partner_compassion_view.xml
+++ b/partner_communication_switzerland/views/partner_compassion_view.xml
@@ -53,7 +53,6 @@
                         </group>
                         <group>
                             <field name="nbmag" />
-                            <field name="calendar" />
                             <field name="birthday_reminder" />
                             <field name="sponsorship_anniversary_card" />
                         </group>

--- a/partner_compassion/models/partner_compassion.py
+++ b/partner_compassion/models/partner_compassion.py
@@ -89,10 +89,6 @@ class ResPartner(models.Model):
         required=True,
         default="default",
     )
-    calendar = fields.Boolean(
-        help="Wants to receive the Compassion calendar.",
-        default=True,
-    )
     birthday_reminder = fields.Boolean(
         help="Indicates if the partner wants to receive a birthday "
         "reminder of his child.",

--- a/partner_compassion/views/partner_compassion_view.xml
+++ b/partner_compassion/views/partner_compassion_view.xml
@@ -262,7 +262,6 @@
                      'default_tax_certificate':'no',
                      'default_thankyou_preference':'none',
                      'default_nbmag':'no_mag',
-                     'default_calendar':0,
                      'default_christmas_card':0,
                      'default_email': email}</attribute>
             </xpath>
@@ -322,7 +321,6 @@
                             </div>
                         </div>
                         <field name="nbmag" />
-                        <field name="calendar" />
                     </group>
                     <group>
                         <group string="Contact information">


### PR DESCRIPTION
# Removal of "Compassion Calendar" Communication Preference

## Problem Description

The **"Compassion Calendar"** communication preference remained across multiple layers of the application despite being obsolete and no longer used in any active delivery process.

This created unnecessary complexity and inconsistencies in partner communication settings.

---

## Justification and Context

This PR fully removes the obsolete communication preference, ensuring consistency across backend logic, database models, and user interfaces.

Analysis confirmed that the calendar distribution was **an old process** involving **physical calendar mailings**, which are no longer performed. No automated workflow or email template relied on this field.

---

## Applied Changes and Fixes

### Backend & Business Logic (Python)

- Removed the `calendar` boolean field from the `res.partner` model.  
- Cleaned up the `compute_inverse_no_physical_letter` method to remove calendar-related logic.  
- Updated the `set_partner_communication_settings` controller to remove `calendar` from allowed fields.

---

### Frontend & User Interface (XML)

- Removed the `calendar` field from Odoo partner and contact forms.  
- Removed `default_calendar` from context initialization.  
- Removed the calendar preference switch from the MyCompassion portal settings page.

---

## Related PRs

This set of improvements is complemented by a related PR in the **Compassion-website** repository:

- PR: [[T2839] - Remove calendar checkbox in communication settings #237](https://github.com/CompassionCH/compassion-website/pull/237)
