### PR TITLE
[T2881] - Migrate mail_template_mandrill

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,6 @@ exclude: |
   ^gifts_payments/|
   ^hr_switzerland/|
   ^mail_activity_to_crm_request/|
-  ^mail_template_mandrill/|
   ^partner_communication_switzerland/|
   ^report_compassion/|
   ^sbc_switzerland/|

--- a/mail_template_mandrill/README.rst
+++ b/mail_template_mandrill/README.rst
@@ -17,7 +17,7 @@ Mail Template Mandrill
     :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
     :alt: License: AGPL-3
 .. |badge3| image:: https://img.shields.io/badge/github-CompassionCH%2Fcompassion--switzerland-lightgray.png?logo=github
-    :target: https://github.com/CompassionCH/compassion-switzerland/tree/14.0/mail_template_mandrill
+    :target: https://github.com/CompassionCH/compassion-switzerland/tree/18.0/mail_template_mandrill
     :alt: CompassionCH/compassion-switzerland
 
 |badge1| |badge2| |badge3|
@@ -43,7 +43,7 @@ Bug Tracker
 Bugs are tracked on `GitHub Issues <https://github.com/CompassionCH/compassion-switzerland/issues>`_.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
-`feedback <https://github.com/CompassionCH/compassion-switzerland/issues/new?body=module:%20mail_template_mandrill%0Aversion:%2014.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+`feedback <https://github.com/CompassionCH/compassion-switzerland/issues/new?body=module:%20mail_template_mandrill%0Aversion:%2018.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
 
 Do not contact contributors directly about support or help with technical issues.
 
@@ -58,6 +58,6 @@ Authors
 Maintainers
 -----------
 
-This module is part of the `CompassionCH/compassion-switzerland <https://github.com/CompassionCH/compassion-switzerland/tree/14.0/mail_template_mandrill>`_ project on GitHub.
+This module is part of the `CompassionCH/compassion-switzerland <https://github.com/CompassionCH/compassion-switzerland/tree/18.0/mail_template_mandrill>`_ project on GitHub.
 
 You are welcome to contribute.

--- a/mail_template_mandrill/__manifest__.py
+++ b/mail_template_mandrill/__manifest__.py
@@ -1,6 +1,7 @@
+# pylint: disable=C8101
 {
     "name": "Mail Template Mandrill",
-    "version": "14.0.1.0.0",
+    "version": "18.0.1.0.0",
     "category": "Mailing",
     "author": "Compassion Switzerland",
     "license": "AGPL-3",
@@ -13,6 +14,6 @@
         "views/mail_template_view.xml",
     ],
     "demo": [],
-    "installable": False,
+    "installable": True,
     "auto_install": False,
 }

--- a/mail_template_mandrill/pyproject.toml
+++ b/mail_template_mandrill/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"

--- a/mail_template_mandrill/static/description/index.html
+++ b/mail_template_mandrill/static/description/index.html
@@ -369,7 +369,7 @@ ul.auto-toc {
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !! source digest: sha256:01cc24c68cdfa8d09916d4f288d340cb321d241b57056681852bed1ab56b7785
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
-<p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/CompassionCH/compassion-switzerland/tree/14.0/mail_template_mandrill"><img alt="CompassionCH/compassion-switzerland" src="https://img.shields.io/badge/github-CompassionCH%2Fcompassion--switzerland-lightgray.png?logo=github" /></a></p>
+<p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/CompassionCH/compassion-switzerland/tree/18.0/mail_template_mandrill"><img alt="CompassionCH/compassion-switzerland" src="https://img.shields.io/badge/github-CompassionCH%2Fcompassion--switzerland-lightgray.png?logo=github" /></a></p>
 <p>This module integrates Mandrill templates with Odoo’s mail templates. It
 allows you to use different Mandrill templates for different languages.</p>
 <div class="section" id="features">
@@ -391,7 +391,7 @@ allows you to use different Mandrill templates for different languages.</p>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/CompassionCH/compassion-switzerland/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
-<a class="reference external" href="https://github.com/CompassionCH/compassion-switzerland/issues/new?body=module:%20mail_template_mandrill%0Aversion:%2014.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**">feedback</a>.</p>
+<a class="reference external" href="https://github.com/CompassionCH/compassion-switzerland/issues/new?body=module:%20mail_template_mandrill%0Aversion:%2018.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**">feedback</a>.</p>
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
@@ -406,7 +406,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </div>
 <div class="section" id="maintainers">
 <h1>Maintainers</h1>
-<p>This module is part of the <a class="reference external" href="https://github.com/CompassionCH/compassion-switzerland/tree/14.0/mail_template_mandrill">CompassionCH/compassion-switzerland</a> project on GitHub.</p>
+<p>This module is part of the <a class="reference external" href="https://github.com/CompassionCH/compassion-switzerland/tree/18.0/mail_template_mandrill">CompassionCH/compassion-switzerland</a> project on GitHub.</p>
 <p>You are welcome to contribute.</p>
 </div>
 </div>

--- a/mail_template_mandrill/views/mail_template_view.xml
+++ b/mail_template_mandrill/views/mail_template_view.xml
@@ -9,10 +9,10 @@
                 <page string="Mailchimp" name="mailchimp">
                     <group>
                         <field name="mailchimp_template_ids">
-                            <tree editable="top">
+                            <list editable="top">
                                 <field name="lang" />
                                 <field name="mailchimp_template" />
-                            </tree>
+                            </list>
                         </field>
                     </group>
                 </page>

--- a/mail_template_mandrill/wizards/mail_compose_message.py
+++ b/mail_template_mandrill/wizards/mail_compose_message.py
@@ -5,9 +5,9 @@ from odoo.tools.safe_eval import safe_eval
 class EmailComposeMessage(models.TransientModel):
     _inherit = "mail.compose.message"
 
-    def get_mail_values(self, res_ids):
+    def _prepare_mail_values(self, res_ids):
         """Attach mailchimp template to e-mail (in SMTP headers)"""
-        mail_values = super().get_mail_values(res_ids)
+        mail_values = super()._prepare_mail_values(res_ids)
         template = self.template_id
         mailchimp_template = template.mailchimp_template_ids.filtered(
             lambda m: m.lang == self.env.lang


### PR DESCRIPTION
# Migration of mail_template_mandrill Module from Odoo 14 to Odoo 18

## Description

This PR covers the technical migration of the `mail_template_mandrill` module from Odoo **14** to **18**.  
The objective is to ensure that email sending logic through the Mandrill (Mailchimp) API remains fully functional with the new email engine hooks introduced in Odoo 18.

---

## Technical Changes

### Python (`mail.compose.message.py`)

- **Method override update**  
  The deprecated/removed `get_mail_values` method has been replaced by an override of `_prepare_mail_values`, as required in Odoo 18.

- **Mandrill header injection preserved**  
  The logic injecting Mandrill-specific SMTP headers based on the recipient language is maintained, relying on `self.env.lang`.

---

### XML Views (`mail_template_view.xml`)

- **View definition update**  
  The Mailchimp template list view definition has been updated to comply with Odoo 18 naming standards:
  - `<tree>` tag replaced by `<list>`

---

## Validation

The migration was validated locally using **MailHog** to intercept outgoing emails without sending real messages.

Validated points:
- **Interception**  
  Emails sent via the chatter or the compose wizard are correctly captured by MailHog.
- **Structure**  
  HTML rendering and email metadata (headers) are correctly generated.
- **Multi-recipient handling**  
  Sending to multiple recipients works as expected, with individual messages received in MailHog.
<img width="512" height="231" alt="mailhog_test" src="https://github.com/user-attachments/assets/bb92658e-ad94-4370-b671-6e50d4c9f461" />

---

## Test Procedure

1. Install the module on an Odoo 18 instance.
2. Start MailHog, for example:
```bash
   docker run -d -p 1025:1025 -p 8025:8025 --name mailhog mailhog/mailhog
```
4. Configure an outgoing mail server pointing to `localhost:1025`.
5. Send a message from a contact form.
6. Verify reception and formatting at `http://localhost:8025`.