### PR TITLE
[T308] FIX: schedule activities are now not posted over and over again

### DIFF
--- a/partner_communication_switzerland/models/res_partner_zoom_attendee.py
+++ b/partner_communication_switzerland/models/res_partner_zoom_attendee.py
@@ -159,16 +159,17 @@ class ZoomAttendee(models.Model):
                         attendee.activity_schedule(
                             "mail.mail_activity_data_todo",
                             summary=summary,
-                            note="This person is not available for the upcoming zoom with "
-                            "new sponsors, but wants to attend the next one. No "
-                            "following session was found, please add him to "
-                            "participants once it's created.",
+                            note="This person is not available for the upcoming "
+                            "zoom with new sponsors, but wants to attend the "
+                            "next one. No following session was found, please "
+                            "add him to participants once it's created.",
                             user_id=user_id,
                         )
 
     def _schedule_task_followup(self, summary: str, user_id: int) -> bool:
         """
-        Notify staff once, and then post monthly reminders if participant was still not added to a zoom session.
+        Notify staff once, and then post monthly reminders if participant was
+        still not added to a zoom session.
 
         :param summary: The title of the scheduled activity
         :param user_id: The user id of the user to notify
@@ -201,7 +202,8 @@ class ZoomAttendee(models.Model):
                     f"Please check if a new video session is available.",
                     subtype_id=self.env.ref("mail.mt_note").id,
                 )
-                act.write({"note": act.note})
+                # update activity so write date updates
+                act.write({})
             # There is already an activity created, don't create a new one
             return False
         # Safe to create first activity

--- a/partner_communication_switzerland/models/res_partner_zoom_attendee.py
+++ b/partner_communication_switzerland/models/res_partner_zoom_attendee.py
@@ -166,13 +166,12 @@ class ZoomAttendee(models.Model):
                             user_id=user_id,
                         )
 
-    def _schedule_task_followup(self, summary: str, user_id: int) -> bool:
+    def _schedule_task_followup(self, summary: str) -> bool:
         """
         Notify staff once, and then post monthly reminders if participant was
         still not added to a zoom session.
 
         :param summary: The title of the scheduled activity
-        :param user_id: The user id of the user to notify
 
         :return: True or False
         """

--- a/partner_communication_switzerland/models/res_partner_zoom_attendee.py
+++ b/partner_communication_switzerland/models/res_partner_zoom_attendee.py
@@ -7,6 +7,7 @@
 #    The licence is in the file __manifest__.py
 #
 ##############################################################################
+from datetime import datetime, timedelta
 from enum import Enum
 
 from odoo import SUPERUSER_ID, api, fields, models
@@ -150,15 +151,61 @@ class ZoomAttendee(models.Model):
                     f"zoom_attendee_{lang}_id"
                 )
                 if user_id:
-                    attendee.activity_schedule(
-                        "mail.mail_activity_data_todo",
-                        summary="Sponsor wants to attend the next Zoom session",
-                        note="This person is not available for the upcoming zoom with "
-                        "new sponsors, but wants to attend the next one. No "
-                        "following session was found, please add him to "
-                        "participants once it's created.",
-                        user_id=user_id,
-                    )
+                    summary = "Sponsor wants to attend the next Zoom session"
+
+                    if attendee._schedule_task_followup(
+                        summary=summary, user_id=user_id
+                    ):
+                        attendee.activity_schedule(
+                            "mail.mail_activity_data_todo",
+                            summary=summary,
+                            note="This person is not available for the upcoming zoom with "
+                            "new sponsors, but wants to attend the next one. No "
+                            "following session was found, please add him to "
+                            "participants once it's created.",
+                            user_id=user_id,
+                        )
+
+    def _schedule_task_followup(self, summary: str, user_id: int) -> bool:
+        """
+        Notify staff once, and then post monthly reminders if participant was still not added to a zoom session.
+
+        :param summary: The title of the scheduled activity
+        :param user_id: The user id of the user to notify
+
+        :return: True or False
+        """
+        self.ensure_one()
+
+        model_id = self.env["ir.model"]._get(self._name).id
+        all_activities = (
+            self.env["mail.activity"]
+            .sudo()
+            .search(
+                [
+                    ("res_model_id", "=", model_id),
+                    ("res_name", "=", self.partner_id.name),
+                    ("summary", "=", summary),
+                ],
+                order="create_date desc",
+            )
+        )
+
+        if all_activities:
+            act = all_activities[0]
+            last_update = fields.Datetime.to_datetime(act.write_date)
+            if last_update < (datetime.now() - timedelta(days=30)):
+                self.message_post(
+                    body=f"<b>Monthly reminder: </b> The follow-up for "
+                    f"{self.partner_id.name} is still pending. "
+                    f"Please check if a new video session is available.",
+                    subtype_id=self.env.ref("mail.mt_note").id,
+                )
+                act.write({"note": act.note})
+            # There is already an activity created, don't create a new one
+            return False
+        # Safe to create first activity
+        return True
 
     def notify_user(self):
         self.ensure_one()

--- a/partner_communication_switzerland/views/res_partner_zoom_session.xml
+++ b/partner_communication_switzerland/views/res_partner_zoom_session.xml
@@ -149,6 +149,10 @@
               states="invited,confirmed,attended"
             />
                         <field name="optional_message" />
+                        <field
+              name="inform_me_for_next_zoom"
+              string="Inform about next Zoom meeting"
+            />
                     </group>
                 </sheet>
                 <div class="oe_chatter">


### PR DESCRIPTION
- FIX: only one scheduled activity is created in case a user wants to be informed about the next video meeting. In case of neglecting it, a notification is posted once a month to remind staff
- FEAT: the option to turn of informing for next zoom meeting is now available in the backend view.