### PR TITLE
[REF] T3150: Refactor QR code UTM generation to use urlencode

### DIFF
--- a/child_switzerland/models/compassion_child.py
+++ b/child_switzerland/models/compassion_child.py
@@ -8,6 +8,7 @@
 #
 ##############################################################################
 from datetime import timedelta
+from urllib.parse import urlencode
 
 import pyqrcode
 
@@ -81,15 +82,20 @@ class CompassionChild(models.Model):
         ).rstrip("/")
 
         # Fetch UTMs from the environment context with defaults
-        utm_medium = self.env.context.get("qr_utm_medium") or "childpack_qr"
-        utm_source = self.env.context.get("qr_utm_source") or "hold_campaign"
-        utm_campaign = self.env.context.get("qr_utm_campaign") or ""
+        utm_params = {
+            "utm_medium": self.env.context.get("qr_utm_medium", "childpack_qr"),
+            "utm_source": self.env.context.get("qr_utm_source", "hold_campaign"),
+        }
 
-        utm_string = f"?utm_medium={utm_medium}&utm_source={utm_source}"
+        # Add utm_campaign param only if provided
+        utm_campaign = self.env.context.get("qr_utm_campaign")
         if utm_campaign:
-            utm_string += f"&utm_campaign={utm_campaign}"
+            utm_params["utm_campaign"] = utm_campaign
+
+        # Safely encode dict to a URL query string
+        utm_params_encoded = urlencode(utm_params)
 
         for child in self:
-            url = f"{base_url}/my2/new-sponsorship/{child.id}{utm_string}"
+            url = f"{base_url}/my2/new-sponsorship/{child.id}?{utm_params_encoded}"
             qr = pyqrcode.create(url)
             child.qr_code_data = qr.png_as_base64_str(15, (0, 84, 166))

--- a/child_switzerland/models/compassion_child.py
+++ b/child_switzerland/models/compassion_child.py
@@ -83,8 +83,8 @@ class CompassionChild(models.Model):
 
         # Fetch UTMs from the environment context with defaults
         utm_params = {
-            "utm_medium": self.env.context.get("qr_utm_medium", "childpack_qr"),
-            "utm_source": self.env.context.get("qr_utm_source", "hold_campaign"),
+            "utm_medium": self.env.context.get("qr_utm_medium") or "childpack_qr",
+            "utm_source": self.env.context.get("qr_utm_source") or "hold_campaign",
         }
 
         # Add utm_campaign param only if provided


### PR DESCRIPTION
## T3150: Refactor UTM Tracking (and fix WordPress sponsorships)
**LINKED TO PR:** https://github.com/CompassionCH/compassion-website/pull/327

Follow-up to T3090 (PR compassion-website #321  and  [compassion-switzerland #1751](https://github.com/CompassionCH/compassion-switzerland/pull/1751).

## The Issue
The initial UTM tracking implementation introduced a critical bug: 
- **Broken Route:** Changing the route converter from `<model>` to `<int>` broke our all QR printed slug based link.
- **Reinventing the Wheel:** The previous code manually extracted and wrote UTM parameters into the session and records, bypassing Odoo's built-in `utm.mixin` functionality which already handles all of this natively via cookies.

## The Solution (Refactored & Simplified)
This PR removes the redundant code and leans on Odoo's UTM utility. 

- **Restored the `<model("compassion.child"):child>` route:** This fixes the WordPress related links. It also ensures backward compatibility, meaning slug-based links and integer-based links will work.
- **Native Odoo UTM Tracking:** Removed the custom UTM extraction logic. Added explicit `utm.mixin` inheritance to `recurring.contract`. Now, Odoo automatically intercepts UTMs from the URL, stores them in cookies, and maps them to the contract upon creation.
- **Fixed Login Redirection:** UTMs and query parameters are no longer lost during the `/web/login` round-trip.
- **Safe QR Code Generation:** (In `compassion-switzerland`) Refactored the QR URL builder to use `urllib.parse.urlencode` for safer parameter construction.

Here is how it works:
<img width="1681" height="803" alt="image" src="https://github.com/user-attachments/assets/7ed9a114-0b12-470a-b004-baca361e4b95" />

The code has been tested locally on the different possibilities.