### PR TITLE
[T3124] FIX: prevent couple names from being re-split on unchanged name write

### DIFF
--- a/partner_compassion/models/partner_compassion.py
+++ b/partner_compassion/models/partner_compassion.py
@@ -346,9 +346,9 @@ class ResPartner(models.Model):
         computations. When the written name still matches the stored
         firstname/lastname combination, we keep them as they are instead of
         re-splitting the name. This prevents corrupting couple names like
-        "Pascal und Simea Hedinger" (firstname="Pascal und Simea",
-        lastname="Hedinger") into firstname="Pascal", lastname="und Simea
-        Hedinger" when the unchanged name is written back (e.g. by the
+        "John und Jane Smith" (firstname="John und Jane",
+        lastname="Smith") into firstname="John", lastname="und Jane
+        Smith" when the unchanged name is written back (e.g. by the
         website checkout during an online donation).
         """
         to_split = self.filtered(

--- a/partner_compassion/models/partner_compassion.py
+++ b/partner_compassion/models/partner_compassion.py
@@ -352,9 +352,11 @@ class ResPartner(models.Model):
         website checkout during an online donation).
         """
         to_split = self.filtered(
-            lambda p: p.name != p._get_computed_name(p.lastname, p.firstname)
+            lambda p: (p.name or "")
+            != (p._get_computed_name(p.lastname, p.firstname) or "")
         )
-        super(ResPartner, to_split)._inverse_name()
+        if to_split:
+            super(ResPartner, to_split)._inverse_name()
 
     @api.model
     def name_search(self, name="", args=None, operator="ilike", limit=100):

--- a/partner_compassion/models/partner_compassion.py
+++ b/partner_compassion/models/partner_compassion.py
@@ -340,6 +340,22 @@ class ResPartner(models.Model):
         res.pop("name", False)
         return res
 
+    def _inverse_name(self):
+        """
+        Fix bug changing the firstname and lastname because of automatic name
+        computations. When the written name still matches the stored
+        firstname/lastname combination, we keep them as they are instead of
+        re-splitting the name. This prevents corrupting couple names like
+        "Pascal und Simea Hedinger" (firstname="Pascal und Simea",
+        lastname="Hedinger") into firstname="Pascal", lastname="und Simea
+        Hedinger" when the unchanged name is written back (e.g. by the
+        website checkout during an online donation).
+        """
+        to_split = self.filtered(
+            lambda p: p.name != p._get_computed_name(p.lastname, p.firstname)
+        )
+        super(ResPartner, to_split)._inverse_name()
+
     @api.model
     def name_search(self, name="", args=None, operator="ilike", limit=100):
         """Extends to use trigram search."""

--- a/sponsorship_switzerland/models/contract_group.py
+++ b/sponsorship_switzerland/models/contract_group.py
@@ -129,7 +129,11 @@ class ContractGroup(models.Model):
         self, invoicing_date, contracts, skip_suspended=True
     ):
         # Avoids generating invoices for Donors of Compassion in CH
-        if set(contracts.mapped("partner_id.id")).intersection({22585,}):
+        if set(contracts.mapped("partner_id.id")).intersection(
+            {
+                22585,
+            }
+        ):
             return True
         return super()._should_skip_invoice_generation(
             invoicing_date, contracts, skip_suspended


### PR DESCRIPTION
Fixes the bug which occurred when an existing couple's name was (over)written (for example during an online donation) by  donation form. 
Now, if the name exists, then it will not be overwritten, preventing the wrong splitting of couple's names 

- Before: _Jane and John Smith_  => firstname: Jane, lastname: and John Smith
- After: _Jane and John Smith_ => firstname: Jane and John, lastname: Smith

Ensured that normal names work just as before. 